### PR TITLE
Move effects to subordinate namespaces

### DIFF
--- a/include/sst/effects/Bonsai.h
+++ b/include/sst/effects/Bonsai.h
@@ -28,7 +28,7 @@
 #include "sst/basic-blocks/dsp/FastMath.h"
 #include "sst/basic-blocks/tables/DbToLinearProvider.h"
 
-namespace sst::effects
+namespace sst::effects::bonsai
 {
 namespace sdsp = sst::basic_blocks::dsp;
 
@@ -715,7 +715,7 @@ template <size_t blockSize> inline void noise_ds4(float &last, float *__restrict
     }
 }
 
-template <typename FXConfig> struct Bonsai : EffectTemplateBase<FXConfig>
+template <typename FXConfig> struct Bonsai : core::EffectTemplateBase<FXConfig>
 {
     // static constexpr double MIDI_0_FREQ = 8.17579891564371;
     // or 440.0 * pow( 2.0, - (69.0/12.0) )
@@ -761,7 +761,7 @@ template <typename FXConfig> struct Bonsai : EffectTemplateBase<FXConfig>
 
     Bonsai(typename FXConfig::GlobalStorage *s, typename FXConfig::EffectStorage *e,
            typename FXConfig::ValueStorage *p)
-        : EffectTemplateBase<FXConfig>(s, e, p)
+        : core::EffectTemplateBase<FXConfig>(s, e, p)
     {
     }
 
@@ -1480,6 +1480,6 @@ inline void Bonsai<FXConfig>::processBlock(float *__restrict dataL, float *__res
     lerp<FXConfig::blockSize>(dataR, outR, mixVal, dataR);
 }
 
-} // namespace sst::effects
+} // namespace sst::effects::bonsai
 
 #endif

--- a/include/sst/effects/ConcreteConfig.h
+++ b/include/sst/effects/ConcreteConfig.h
@@ -21,7 +21,7 @@
 #ifndef INCLUDE_SST_EFFECTS_CONCRETECONFIG_H
 #define INCLUDE_SST_EFFECTS_CONCRETECONFIG_H
 
-namespace sst::effects
+namespace sst::effects::core
 {
 /**
  * ConcreteConfig is a simple implementation of the Configuration protocol which
@@ -98,6 +98,6 @@ struct ConcreteConfig
 
     static inline float dbToLinear(GlobalStorage *s, float f) { return 1; }
 };
-} // namespace sst::effects
+} // namespace sst::effects::core
 
 #endif // SURGE_CONCRETECONFIG_H

--- a/include/sst/effects/Delay.h
+++ b/include/sst/effects/Delay.h
@@ -37,12 +37,12 @@
 
 #include "sst/basic-blocks/tables/SincTableProvider.h"
 
-namespace sst::effects
+namespace sst::effects::delay
 {
 namespace sdsp = sst::basic_blocks::dsp;
 namespace mech = sst::basic_blocks::mechanics;
 
-template <typename FXConfig> struct Delay : EffectTemplateBase<FXConfig>
+template <typename FXConfig> struct Delay : core::EffectTemplateBase<FXConfig>
 {
     enum delay_params
     {
@@ -78,7 +78,7 @@ template <typename FXConfig> struct Delay : EffectTemplateBase<FXConfig>
 
     Delay(typename FXConfig::GlobalStorage *s, typename FXConfig::EffectStorage *e,
           typename FXConfig::ValueStorage *p)
-        : EffectTemplateBase<FXConfig>(s, e, p), lp(s), hp(s)
+        : core::EffectTemplateBase<FXConfig>(s, e, p), lp(s), hp(s)
     {
         // We should no longer need this
         mix.set_blocksize(FXConfig::blockSize);
@@ -167,8 +167,8 @@ template <typename FXConfig> struct Delay : EffectTemplateBase<FXConfig>
     // TODO - we've wanted a sample rate adjustable max for a while.
     // Still don't have it here.
     static constexpr int max_delay_length{1 << 18};
-    typename EffectTemplateBase<FXConfig>::lipol_ps_blocksz feedback, crossfeed, aligpan, pan, mix,
-        width;
+    typename core::EffectTemplateBase<FXConfig>::lipol_ps_blocksz feedback, crossfeed, aligpan, pan,
+        mix, width;
     float buffer alignas(
         16)[2][max_delay_length + sst::basic_blocks::tables::SurgeSincTableProvider::FIRipol_N];
 
@@ -176,7 +176,7 @@ template <typename FXConfig> struct Delay : EffectTemplateBase<FXConfig>
     bool inithadtempo;
     float envf;
     int wpos;
-    typename EffectTemplateBase<FXConfig>::BiquadFilterType lp, hp;
+    typename core::EffectTemplateBase<FXConfig>::BiquadFilterType lp, hp;
     double lfophase;
     float LFOval;
     bool LFOdirection, FBsign;
@@ -430,5 +430,5 @@ template <typename FXConfig> inline void Delay<FXConfig>::processBlock(float *da
     wpos += FXConfig::blockSize;
     wpos = wpos & (max_delay_length - 1);
 }
-} // namespace sst::effects
+} // namespace sst::effects::delay
 #endif // SURGE_DELAY_H

--- a/include/sst/effects/EffectCore.h
+++ b/include/sst/effects/EffectCore.h
@@ -82,7 +82,7 @@
 
 #include <type_traits>
 
-namespace sst::effects
+namespace sst::effects::core
 {
 // Todo: as we port consider this FXConfig::BaseClass being a bit more configurable.
 template <typename FXConfig> struct EffectTemplateBase : public FXConfig::BaseClass
@@ -242,6 +242,6 @@ template <typename FXConfig> struct EffectTemplateBase : public FXConfig::BaseCl
         sdsp::decodeMS<FXConfig::blockSize>(M, S, L, R);
     }
 };
-} // namespace sst::effects
+} // namespace sst::effects::core
 
 #endif

--- a/include/sst/effects/EffectCoreDetails.h
+++ b/include/sst/effects/EffectCoreDetails.h
@@ -25,7 +25,7 @@
 #include <type_traits>
 #include <iostream>
 
-namespace sst::effects::details
+namespace sst::effects::core::details
 {
 
 // Thanks Jatin!
@@ -52,6 +52,6 @@ HAS_MEMBER(temposyncInitialized);
 HAS_MEMBER(temposyncRatioInv);
 HAS_MEMBER(deformType);
 
-} // namespace sst::effects::details
+} // namespace sst::effects::core::details
 
 #endif // SURGE_EFFECTCOREDETAILS_H

--- a/include/sst/effects/Flanger.h
+++ b/include/sst/effects/Flanger.h
@@ -26,11 +26,11 @@
 #include "sst/basic-blocks/dsp/Lag.h"
 #include "sst/basic-blocks/dsp/BlockInterpolators.h"
 
-namespace sst::effects
+namespace sst::effects::flanger
 {
 namespace sdsp = sst::basic_blocks::dsp;
 
-template <typename FXConfig> struct Flanger : EffectTemplateBase<FXConfig>
+template <typename FXConfig> struct Flanger : core::EffectTemplateBase<FXConfig>
 {
     static constexpr double MIDI_0_FREQ = 8.17579891564371; // or 440.0 * pow( 2.0, - (69.0/12.0 ) )
 
@@ -79,7 +79,7 @@ template <typename FXConfig> struct Flanger : EffectTemplateBase<FXConfig>
 
     Flanger(typename FXConfig::GlobalStorage *s, typename FXConfig::EffectStorage *e,
             typename FXConfig::ValueStorage *p)
-        : EffectTemplateBase<FXConfig>(s, e, p)
+        : core::EffectTemplateBase<FXConfig>(s, e, p)
     {
     }
 
@@ -602,6 +602,6 @@ inline void Flanger<FXConfig>::processBlock(float *__restrict dataL, float *__re
     this->applyWidth(dataL, dataR, width);
 }
 
-} // namespace sst::effects
+} // namespace sst::effects::flanger
 
 #endif

--- a/include/sst/effects/Reverb1.h
+++ b/include/sst/effects/Reverb1.h
@@ -29,12 +29,12 @@
 #include "sst/basic-blocks/mechanics/block-ops.h"
 #include "sst/basic-blocks/mechanics/simd-ops.h"
 
-namespace sst::effects
+namespace sst::effects::reverb1
 {
 namespace sdsp = sst::basic_blocks::dsp;
 namespace mech = sst::basic_blocks::mechanics;
 
-template <typename FXConfig> struct Reverb1 : EffectTemplateBase<FXConfig>
+template <typename FXConfig> struct Reverb1 : core::EffectTemplateBase<FXConfig>
 {
     enum rev1_params
     {
@@ -127,7 +127,7 @@ template <typename FXConfig> struct Reverb1 : EffectTemplateBase<FXConfig>
     float out_tap alignas(16)[rev_taps];
     float predelay alignas(16)[max_rev_dly];
     int delay_time alignas(16)[rev_taps];
-    typename EffectTemplateBase<FXConfig>::lipol_ps_blocksz mix, width;
+    typename core::EffectTemplateBase<FXConfig>::lipol_ps_blocksz mix, width;
 
     void update_rtime();
     void update_rsize() { loadpreset(shape); }
@@ -146,7 +146,7 @@ template <typename FXConfig> struct Reverb1 : EffectTemplateBase<FXConfig>
     double modphase{0.0};
     int shape{0};
     float lastf[numParams];
-    typename EffectTemplateBase<FXConfig>::BiquadFilterType band1, locut, hicut;
+    typename core::EffectTemplateBase<FXConfig>::BiquadFilterType band1, locut, hicut;
     int ringout_time;
     int b{0};
 
@@ -156,7 +156,7 @@ template <typename FXConfig> struct Reverb1 : EffectTemplateBase<FXConfig>
 template <typename FXConfig>
 Reverb1<FXConfig>::Reverb1(typename FXConfig::GlobalStorage *s, typename FXConfig::EffectStorage *e,
                            typename FXConfig::ValueStorage *p)
-    : EffectTemplateBase<FXConfig>(s, e, p), band1(s), locut(s), hicut(s)
+    : core::EffectTemplateBase<FXConfig>(s, e, p), band1(s), locut(s), hicut(s)
 {
 }
 
@@ -423,6 +423,6 @@ template <typename FXConfig> inline void Reverb1<FXConfig>::update_rtime()
     ringout_time = (int)t;
 }
 
-} // namespace sst::effects
+} // namespace sst::effects::reverb1
 
 #endif

--- a/tests/concrete-runs.cpp
+++ b/tests/concrete-runs.cpp
@@ -50,8 +50,8 @@ template <typename T> struct Tester
 
         INFO("Starting test with concrete implementation " << T::effectName);
 
-        auto gs = sst::effects::ConcreteConfig::GlobalStorage(48000);
-        auto es = sfx::ConcreteConfig::EffectStorage();
+        auto gs = sst::effects::core::ConcreteConfig::GlobalStorage(48000);
+        auto es = sfx::core::ConcreteConfig::EffectStorage();
 
         auto fx = std::make_unique<FX>(&gs, &es, nullptr);
 
@@ -61,14 +61,14 @@ template <typename T> struct Tester
 
         fx->initialize();
 
-        float L alignas(16)[sfx::ConcreteConfig::blockSize],
-            R alignas(16)[sfx::ConcreteConfig::blockSize];
+        float L alignas(16)[sfx::core::ConcreteConfig::blockSize],
+            R alignas(16)[sfx::core::ConcreteConfig::blockSize];
 
         float phase = 0.f;
         float dphase = 1.0 / 317.4;
         for (int blocks = 0; blocks < 1000; ++blocks)
         {
-            for (int s = 0; s < sfx::ConcreteConfig::blockSize; ++s)
+            for (int s = 0; s < sfx::core::ConcreteConfig::blockSize; ++s)
             {
                 L[s] = 0.6 * (phase * 2 - 1);
                 R[s] = 0.57 * (phase > 0.7 ? 1 : -1);
@@ -79,7 +79,7 @@ template <typename T> struct Tester
 
             fx->processBlock(L, R);
 
-            for (int s = 0; s < sfx::ConcreteConfig::blockSize; ++s)
+            for (int s = 0; s < sfx::core::ConcreteConfig::blockSize; ++s)
             {
                 REQUIRE(fabs(L[s]) < 2.0);
                 REQUIRE(fabs(R[s]) < 2.0);
@@ -90,8 +90,8 @@ template <typename T> struct Tester
 
 TEST_CASE("Can Run Types with Concrete Config")
 {
-    SECTION("Flanger") { Tester<sfx::Flanger<sfx::ConcreteConfig>>::TestFX(); }
-    SECTION("Reverb1") { Tester<sfx::Reverb1<sfx::ConcreteConfig>>::TestFX(); }
-    SECTION("Delay") { Tester<sfx::Delay<sfx::ConcreteConfig>>::TestFX(); }
-    SECTION("Bonsai") { Tester<sfx::Bonsai<sfx::ConcreteConfig>>::TestFX(); }
+    SECTION("Flanger") { Tester<sfx::flanger::Flanger<sfx::core::ConcreteConfig>>::TestFX(); }
+    SECTION("Reverb1") { Tester<sfx::reverb1::Reverb1<sfx::core::ConcreteConfig>>::TestFX(); }
+    SECTION("Delay") { Tester<sfx::delay::Delay<sfx::core::ConcreteConfig>>::TestFX(); }
+    SECTION("Bonsai") { Tester<sfx::bonsai::Bonsai<sfx::core::ConcreteConfig>>::TestFX(); }
 }

--- a/tests/create-effect.cpp
+++ b/tests/create-effect.cpp
@@ -109,8 +109,8 @@ template <typename T> struct Tester
 
 TEST_CASE("Can Create Types")
 {
-    SECTION("Flanger") { Tester<sst::effects::Flanger<TestConfig>>::TestFX(); }
-    SECTION("Reverb1") { Tester<sst::effects::Reverb1<TestConfig>>::TestFX(); }
-    SECTION("Delay") { Tester<sst::effects::Delay<TestConfig>>::TestFX(); }
-    SECTION("Bonsai") { Tester<sst::effects::Bonsai<TestConfig>>::TestFX(); }
+    SECTION("Flanger") { Tester<sst::effects::flanger::Flanger<TestConfig>>::TestFX(); }
+    SECTION("Reverb1") { Tester<sst::effects::reverb1::Reverb1<TestConfig>>::TestFX(); }
+    SECTION("Delay") { Tester<sst::effects::delay::Delay<TestConfig>>::TestFX(); }
+    SECTION("Bonsai") { Tester<sst::effects::bonsai::Bonsai<TestConfig>>::TestFX(); }
 }

--- a/tests/sfinae-test.cpp
+++ b/tests/sfinae-test.cpp
@@ -101,7 +101,7 @@ TEST_CASE("SFINAE gives us extras")
 {
     SECTION("On Missing")
     {
-        auto ec = std::make_unique<sst::effects::EffectTemplateBase<NoExtraConfig>>(
+        auto ec = std::make_unique<sst::effects::core::EffectTemplateBase<NoExtraConfig>>(
             nullptr, nullptr, nullptr);
         REQUIRE(ec->floatValue(0) == 17.2f);
         REQUIRE(ec->floatValueExtended(0) == 17.2f);
@@ -113,8 +113,8 @@ TEST_CASE("SFINAE gives us extras")
 
     SECTION("On Not Missing")
     {
-        auto ec = std::make_unique<sst::effects::EffectTemplateBase<ExtraConfig>>(nullptr, nullptr,
-                                                                                  nullptr);
+        auto ec = std::make_unique<sst::effects::core::EffectTemplateBase<ExtraConfig>>(
+            nullptr, nullptr, nullptr);
         REQUIRE(ec->floatValue(0) == 17.2f);
         REQUIRE(ec->floatValueExtended(0) == 37.4f);
         REQUIRE(ec->temposyncInitialized() == false);


### PR DESCRIPTION
so sst::effects::delay::Delay etc... so standalone helper functions are scoped to a per-fx. add a core:: for the shared things.