### PR TITLE
Allow Reverb1 Room Size to Modulate

### DIFF
--- a/include/sst/effects/Reverb1.h
+++ b/include/sst/effects/Reverb1.h
@@ -314,9 +314,10 @@ inline void Reverb1<FXConfig>::processBlock(float *__restrict dataL, float *__re
 
 template <typename FXConfig> inline void Reverb1<FXConfig>::loadpreset(int id)
 {
-    shape = id;
+    if (shape != id)
+        clear_buffers();
 
-    clear_buffers();
+    shape = id;
 
     switch (id)
     {


### PR DESCRIPTION
It always cou,d just it cleared a buffer when you did improperly. So now it doesn't clear that buffer any more.