### PR TITLE
Clear reverb buffers on re-initialize

### DIFF
--- a/include/sst/effects/Reverb1.h
+++ b/include/sst/effects/Reverb1.h
@@ -196,6 +196,8 @@ template <typename FXConfig> inline void Reverb1<FXConfig>::initialize()
         delay_pan_R[t] = sqrt(0.5 + 0.495 * xbp);
     }
     delay_pos = 0;
+
+    clear_buffers();
 }
 
 template <typename FXConfig>


### PR DESCRIPTION
This stops an occasionaly noise-on-patch-switch which was caused by 3e0b59f27176841ce54486879496f391ca0ab2bb