### PR TITLE
VoiceEffect Init to PMD Default

### DIFF
--- a/include/sst/voice-effects/VoiceEffectCore.h
+++ b/include/sst/voice-effects/VoiceEffectCore.h
@@ -139,6 +139,21 @@ template <typename VFXConfig> struct VoiceEffectTemplateBase : public VFXConfig:
     void preReservePool(size_t s) { VFXConfig::preReservePool(asBase(), s); }
     uint8_t *checkoutBlock(size_t s) { return VFXConfig::checkoutBlock(asBase(), s); }
     void returnBlock(uint8_t *d, size_t s) { VFXConfig::returnBlock(asBase(), d, s); }
+
+    template <typename T> void initToParamMetadataDefault(T *that)
+    {
+        for (int i = 0; i < T::numFloatParams; ++i)
+        {
+            that->setFloatParam(i, that->paramAt(i).defaultVal);
+        }
+        if constexpr (T::numIntParams)
+        {
+            for (int i = 0; i < T::numIntParams; ++i)
+            {
+                that->setIntParam(i, that->intParamAt(i).defaultVal);
+            }
+        }
+    }
 };
 } // namespace sst::voice_effects::core
 

--- a/include/sst/voice-effects/distortion/BitCrusher.h
+++ b/include/sst/voice-effects/distortion/BitCrusher.h
@@ -58,15 +58,19 @@ template <typename VFXConfig> struct BitCrusher : core::VoiceEffectTemplateBase<
         switch ((bc_fparams)idx)
         {
         case bc_samplerate:
-            return pmd().asAudibleFrequency().withRange(-12, 80).withName("sampleRate");
+            return pmd()
+                .asAudibleFrequency()
+                .withRange(-12, 80)
+                .withName("sampleRate")
+                .withDefault(7.5);
         case bc_bitdepth:
-            return pmd().asPercent().withName("bitdepth");
+            return pmd().asPercent().withName("bitdepth").withDefault(1.f);
         case bc_zeropoint:
-            return pmd().asPercent().withName("zeropoint");
+            return pmd().asPercent().withName("zeropoint").withDefault(0.f);
         case bc_cutoff:
-            return pmd().asAudibleFrequency().withName("cutoff");
+            return pmd().asAudibleFrequency().withName("cutoff").withDefault(5.f);
         case bc_resonance:
-            return pmd().asPercent().withName("resonance");
+            return pmd().asPercent().withName("resonance").withDefault(0.f);
         default:
             break;
         }
@@ -74,14 +78,7 @@ template <typename VFXConfig> struct BitCrusher : core::VoiceEffectTemplateBase<
         return pmd().withName("Unknown " + std::to_string(idx));
     }
 
-    void initVoiceEffectParams()
-    {
-        this->setFloatParam(bc_samplerate, 7.5f);
-        this->setFloatParam(bc_bitdepth, 1.f);
-        this->setFloatParam(bc_zeropoint, 0.f);
-        this->setFloatParam(bc_cutoff, 5.0f);
-        this->setFloatParam(bc_resonance, 0.f);
-    }
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
     void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
                        float pitch)

--- a/include/sst/voice-effects/distortion/Microgate.h
+++ b/include/sst/voice-effects/distortion/Microgate.h
@@ -70,13 +70,13 @@ template <typename VFXConfig> struct MicroGate : core::VoiceEffectTemplateBase<V
         switch ((mg_fparams)idx)
         {
         case mg_hold:
-            return pmd().asLog2SecondsRange(-8, 5, -3).withName("hold");
+            return pmd().asLog2SecondsRange(-8, 5, -3).withName("hold").withDefault(-3.f);
         case mg_loop:
-            return pmd().asPercent().withName("loop");
+            return pmd().asPercent().withName("loop").withDefault(0.5f);
         case mg_threshold:
-            return pmd().asLinearDecibel().withName("threshold");
+            return pmd().asLinearDecibel().withName("threshold").withDefault(-12.f);
         case mg_reduction:
-            return pmd().asLinearDecibel().withName("reduction");
+            return pmd().asLinearDecibel().withName("reduction").withDefault(-96.f);
         case mg_num_params:
             break;
         }
@@ -96,13 +96,7 @@ template <typename VFXConfig> struct MicroGate : core::VoiceEffectTemplateBase<V
         }
     }
 
-    void initVoiceEffectParams()
-    {
-        this->setFloatParam(0, -3.f);
-        this->setFloatParam(1, 0.5f);
-        this->setFloatParam(2, -12.f);
-        this->setFloatParam(3, -96.f);
-    }
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
     void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
                        float pitch)

--- a/include/sst/voice-effects/waveshaper/WaveShaper.h
+++ b/include/sst/voice-effects/waveshaper/WaveShaper.h
@@ -96,7 +96,7 @@ template <typename VFXConfig> struct WaveShaper : core::VoiceEffectTemplateBase<
                 .withRange(0, 2)
                 .withName("Type")
                 .withUnorderedMapFormatting({{0, "Soft"}, {1, "OJD"}, {2, "WCFold"}})
-                .withDefault(0);
+                .withDefault(1);
         case WaveShaperIntParams::oversample:
             return pmd().asBool().withName("OverSample").withDefault(0);
         default:
@@ -106,14 +106,7 @@ template <typename VFXConfig> struct WaveShaper : core::VoiceEffectTemplateBase<
         return pmd().asInt().withRange(0, 1).withName("Error");
     }
 
-    void initVoiceEffectParams()
-    {
-        this->setFloatParam((int)WaveShaperFloatParams::drive, 0.f);
-        this->setFloatParam((int)WaveShaperFloatParams::bias, 0.f);
-        this->setFloatParam((int)WaveShaperFloatParams::postgain, 0.f);
-
-        this->setIntParam((int)WaveShaperIntParams::type, 1); // force to ojd for now
-    }
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
     template <bool stereo>
     void processInternalOS(float *datainL, float *datainR, float *dataoutL, float *dataoutR)


### PR DESCRIPTION
The initVoiceEffectParams() call now just initalizes to eh default values on the param meta data; the param meta data has correct default values.