### PR TITLE
Remove the half-rate filter in WS and included in Sync

### DIFF
--- a/include/sst/voice-effects/generator/GenPulseSync.h
+++ b/include/sst/voice-effects/generator/GenPulseSync.h
@@ -23,7 +23,6 @@
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/BlockInterpolators.h"
-#include "sst/filters/HalfRateFilter.h"
 #include "sst/basic-blocks/mechanics/block-ops.h"
 #include "sst/basic-blocks/tables/SincTableProvider.h"
 


### PR DESCRIPTION
Since the voice pipeline itself can now oversample, remove the up/down CPU cost per voice of the waveshaper internal oversampler.