### PR TITLE
Make oversampling ratio available to effects

### DIFF
--- a/include/sst/voice-effects/VoiceEffectCore.h
+++ b/include/sst/voice-effects/VoiceEffectCore.h
@@ -167,6 +167,27 @@ template <typename VFXConfig> struct VoiceEffectTemplateBase : public VFXConfig:
         }
     }
 
+    template <typename T, typename = void> struct has_oversampling : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct has_oversampling<T, std::void_t<decltype(&T::oversamplingRatio)>> : std::true_type
+    {
+    };
+
+    constexpr int16_t getOversamplingRatio()
+    {
+        if constexpr (has_oversampling<VFXConfig>::value)
+        {
+            return VFXConfig::oversamplingRatio;
+        }
+        else
+        {
+            return 1;
+        }
+    }
+
     using BiquadFilterType =
         sst::filters::Biquad::BiquadFilter<VoiceEffectTemplateBase<VFXConfig>, VFXConfig::blockSize,
                                            VoiceEffectTemplateBase<VFXConfig>>;


### PR DESCRIPTION
If you are actively oversampling some fx may want to behave differently. Make a ratio available as a constexpr which is sfinaed away

Addresses https://github.com/surge-synthesizer/shortcircuit-xt/issues/891