### PR TITLE
Temposync voice processors

### DIFF
--- a/include/sst/voice-effects/VoiceEffectCore.h
+++ b/include/sst/voice-effects/VoiceEffectCore.h
@@ -214,7 +214,6 @@ template <typename VFXConfig> struct VoiceEffectTemplateBase : public VFXConfig:
         assert(tempoPointer);
         if (tempo != *tempoPointer)
         {
-            std::cout << "Updating tempo " << *tempoPointer << " " << __FILE__ << std::endl;
             tempo = *tempoPointer;
             temposyncratio = tempo / 120.0;
             temposyncratioinv = 1.0 / temposyncratio;

--- a/include/sst/voice-effects/delay/Chorus.h
+++ b/include/sst/voice-effects/delay/Chorus.h
@@ -104,14 +104,7 @@ template <typename VFXConfig> struct Chorus : core::VoiceEffectTemplateBase<VFXC
         case fpFeedback:
             return pmd().asPercent().withDefault(0.f).withName("Feedback");
         case fpRate:
-            return pmd()
-                .asFloat()
-                .withRange(-3, 4)
-                .withPolarity(pmd::ParamMetaData::Polarity::UNIPOLAR_POSITIVE)
-                // .temposyncable()
-                // .withTemposyncMultiplier(-1)
-                .withATwoToTheBFormatting(1, 1, "Hz")
-                .withName("Rate");
+            return pmd().asLfoRate(-3, 4).withName("Rate");
         case fpDepth:
             return pmd()
                 .asFloat()

--- a/include/sst/voice-effects/modulation/Phaser.h
+++ b/include/sst/voice-effects/modulation/Phaser.h
@@ -80,14 +80,7 @@ template <typename VFXConfig> struct Phaser : core::VoiceEffectTemplateBase<VFXC
         case fpResonance:
             return pmd().asPercent().withDefault(0.707).withName("Resonance");
         case fpRate:
-            return pmd()
-                .asFloat()
-                .withRange(-3, 4)
-                .withPolarity(pmd::ParamMetaData::Polarity::UNIPOLAR_POSITIVE)
-                // .temposyncable()
-                // .withTemposyncMultiplier(-1)
-                .withATwoToTheBFormatting(1, 1, "Hz")
-                .withName("Rate");
+            return pmd().asLfoRate(-3, 4).withName("Rate");
         case fpDepth:
             return pmd()
                 .asFloat()

--- a/include/sst/voice-effects/modulation/Tremolo.h
+++ b/include/sst/voice-effects/modulation/Tremolo.h
@@ -67,14 +67,7 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
         case fpVolume:
             return pmd().asLinearDecibel(-60.f, 12.f).withName("Volume");
         case fpRate:
-            return pmd()
-                .asFloat()
-                .withRange(-3, 4)
-                .withPolarity(pmd::ParamMetaData::Polarity::UNIPOLAR_POSITIVE)
-                // .temposyncable()
-                // .withTemposyncMultiplier(-1)
-                .withATwoToTheBFormatting(1, 1, "Hz")
-                .withName("Rate");
+            return pmd().asLfoRate(-3, 4).withName("Rate");
         case fpDepth:
             return pmd()
                 .asFloat()
@@ -444,7 +437,7 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
 
     // How does it know which MonoTo... function to choose? By first calling this.
     bool getMonoToStereoSetting() const { return this->getIntParam(ipStereo) > 0; }
-
+    
     bool enableKeytrack(bool b)
     {
         auto res = (b != keytrackOn);


### PR DESCRIPTION
Add temposync communication to the voice processors. Turns out the SimpleLFO has a bit of drift due to float vs double which we need to clean up, but the basic idea is right, so merge this then open a followup issue.