### PR TITLE
Fix new noise procs, add tests

### DIFF
--- a/include/sst/voice-effects/generator/TiltNoise.h
+++ b/include/sst/voice-effects/generator/TiltNoise.h
@@ -24,6 +24,7 @@
 #include "../VoiceEffectCore.h"
 
 #include <iostream>
+#include <cmath>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/rng_gen.h"
@@ -36,7 +37,7 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
 
     static constexpr int numFloatParams{2};
     static constexpr int numIntParams{1};
-    
+
     basic_blocks::dsp::RNGGen rngGen;
 
     enum FloatParams
@@ -83,14 +84,14 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
 
     void initVoiceEffect() {}
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
-    
+
     void setCoeffs()
     {
         float slope = this->getFloatParam(fpTilt) / 2;
         float posGain = this->dbToLinear(slope);
         float negGain = this->dbToLinear(-1 * slope);
         float res = .07f;
-        
+
         if (slope != priorSlope)
         {
             for (int i = 0; i < 11; ++i)
@@ -98,11 +99,15 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
                 float freq = std::powf(2, (i + 1.f)) * 10.f;
                 if (i < 6)
                 {
-                    filters[i].template setCoeffForBlock<VFXConfig::blockSize>(filters::CytomicSVF::Mode::LOW_SHELF, freq, res, this->getSampleRateInv(), negGain);
+                    filters[i].template setCoeffForBlock<VFXConfig::blockSize>(
+                        filters::CytomicSVF::Mode::LOW_SHELF, freq, res, this->getSampleRateInv(),
+                        negGain);
                 }
                 else
                 {
-                    filters[i].template setCoeffForBlock<VFXConfig::blockSize>(filters::CytomicSVF::Mode::HIGH_SHELF, freq, res, this->getSampleRateInv(), posGain);
+                    filters[i].template setCoeffForBlock<VFXConfig::blockSize>(
+                        filters::CytomicSVF::Mode::HIGH_SHELF, freq, res, this->getSampleRateInv(),
+                        posGain);
                 }
             }
             priorSlope = slope;
@@ -120,7 +125,7 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
                        float pitch)
     {
         bool stereo = this->getIntParam(ipStereo);
-        
+
         float atten = this->getFloatParam(fpTilt);
         if (atten > 0)
         {
@@ -129,20 +134,21 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
         atten = this->dbToLinear(atten);
         float level = this->getFloatParam(fpLevel);
         level = level * level * level;
-        
+
         setCoeffs();
-        
+
         for (int i = 0; i < VFXConfig::blockSize; i++)
         {
             dataoutL[i] = rngGen.randPM1();
             dataoutR[i] = stereo ? rngGen.randPM1() : dataoutL[i];
-            
+
             dataoutL[i] *= level * atten;
             dataoutR[i] *= level * atten;
         }
         for (int i = 0; i < 11; ++i)
         {
-            filters[i].template processBlock<VFXConfig::blockSize>(dataoutL, dataoutR, dataoutL, dataoutR);
+            filters[i].template processBlock<VFXConfig::blockSize>(dataoutL, dataoutR, dataoutL,
+                                                                   dataoutR);
         }
     }
 
@@ -154,29 +160,29 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
             atten *= -4.f;
         }
         atten = this->dbToLinear(atten);
-        
+
         float level = this->getFloatParam(fpLevel);
         level = level * level * level;
-        
+
         setCoeffs();
-        
+
         for (int i = 0; i < VFXConfig::blockSize; i++)
         {
             dataout[i] = rngGen.randPM1();
             dataout[i] *= level * atten;
         }
-        
+
         for (int i = 0; i < 11; ++i)
         {
             filters[i].template processBlock<VFXConfig::blockSize>(dataout, dataout);
         }
     }
-    
+
     void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }
-    
+
     bool getMonoToStereoSetting() const { return this->getIntParam(ipStereo) > 0; }
 
   protected:

--- a/include/sst/voice-effects/generator/TiltNoise.h
+++ b/include/sst/voice-effects/generator/TiltNoise.h
@@ -24,7 +24,7 @@
 #include "../VoiceEffectCore.h"
 
 #include <iostream>
-#include <cmath>
+#include <math>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/rng_gen.h"
@@ -96,7 +96,7 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
         {
             for (int i = 0; i < 11; ++i)
             {
-                float freq = std::powf(2, (i + 1.f)) * 10.f;
+                float freq = powf(2, (i + 1.f)) * 10.f;
                 if (i < 6)
                 {
                     filters[i].template setCoeffForBlock<VFXConfig::blockSize>(

--- a/include/sst/voice-effects/generator/TiltNoise.h
+++ b/include/sst/voice-effects/generator/TiltNoise.h
@@ -24,7 +24,7 @@
 #include "../VoiceEffectCore.h"
 
 #include <iostream>
-#include <math>
+#include <math.h>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/rng_gen.h"

--- a/include/sst/voice-effects/modulation/NoiseAM.h
+++ b/include/sst/voice-effects/modulation/NoiseAM.h
@@ -24,7 +24,7 @@
 #include "../VoiceEffectCore.h"
 
 #include <iostream>
-#include <cmath>
+#include <math>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/BlockInterpolators.h"
@@ -115,7 +115,7 @@ template <typename VFXConfig> struct NoiseAM : core::VoiceEffectTemplateBase<VFX
         {
             for (int i = 0; i < 11; ++i)
             {
-                float freq = std::powf(2, (i + 1.f)) * 10.f;
+                float freq = powf(2, (i + 1.f)) * 10.f;
                 if (i < 6)
                 {
                     filters[i].template setCoeffForBlock<VFXConfig::blockSize>(
@@ -222,8 +222,8 @@ template <typename VFXConfig> struct NoiseAM : core::VoiceEffectTemplateBase<VFX
             noiseL[i] *= depth;
             noiseR[i] *= depth;
 
-            auto envL = mode ? datainL[i] : std::fabsf(datainL[i]);
-            auto envR = mode ? datainR[i] : std::fabsf(datainR[i]);
+            auto envL = mode ? datainL[i] : fabsf(datainL[i]);
+            auto envR = mode ? datainR[i] : fabsf(datainR[i]);
 
             auto overL = std::min(threshold - envL, 0.f);
             auto overR = std::min(threshold - envR, 0.f);
@@ -257,7 +257,7 @@ template <typename VFXConfig> struct NoiseAM : core::VoiceEffectTemplateBase<VFX
         {
             noise[i] *= depth;
 
-            auto env = mode ? datain[i] : std::fabsf(datain[i]);
+            auto env = mode ? datain[i] : fabsf(datain[i]);
 
             auto over = std::min(threshold - env, 0.f);
 

--- a/include/sst/voice-effects/modulation/NoiseAM.h
+++ b/include/sst/voice-effects/modulation/NoiseAM.h
@@ -24,6 +24,7 @@
 #include "../VoiceEffectCore.h"
 
 #include <iostream>
+#include <cmath>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/BlockInterpolators.h"

--- a/include/sst/voice-effects/modulation/NoiseAM.h
+++ b/include/sst/voice-effects/modulation/NoiseAM.h
@@ -24,7 +24,7 @@
 #include "../VoiceEffectCore.h"
 
 #include <iostream>
-#include <math>
+#include <math.h>
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "sst/basic-blocks/dsp/BlockInterpolators.h"

--- a/tests/create-voice-effect.cpp
+++ b/tests/create-voice-effect.cpp
@@ -43,6 +43,9 @@
 #include "sst/voice-effects/modulation/Tremolo.h"
 #include "sst/voice-effects/modulation/Phaser.h"
 #include "sst/voice-effects/modulation/FMFilter.h"
+#include "sst/voice-effects/generator/TiltNoise.h"
+#include "sst/voice-effects/modulation/NoiseAM.h"
+
 struct VTestConfig
 {
     struct BaseClass
@@ -162,4 +165,6 @@ TEST_CASE("Can Create Voice FX")
     {
         VTester<sst::voice_effects::modulation::FMFilter<VTestConfig>>::TestVFX();
     }
+    SECTION("Tilt Noise") { VTester<sst::voice_effects::generator::TiltNoise<VTestConfig>>::TestVFX(); }
+    SECTION("Phaser") { VTester<sst::voice_effects::modulation::NoiseAM<VTestConfig>>::TestVFX(); }
 }


### PR DESCRIPTION
Last commit added a couple new noise processors, but didn't add them to the test runs. Thus I failed to realize I'd missed a <cmath> include. Fix!