### PR TITLE
Parameter deactivation available and used in waveshaper

### DIFF
--- a/include/sst/voice-effects/VoiceEffectCore.h
+++ b/include/sst/voice-effects/VoiceEffectCore.h
@@ -201,6 +201,7 @@ template <typename VFXConfig> struct VoiceEffectTemplateBase : public VFXConfig:
     HASMEM(oversamplingRatio, constexpr int16_t getOversamplingRatio(), 1, );
     HASMEM(getTempoPointer, double *getBaseTempoPointer(), &defaultTempo, (asBase()));
     HASMEM(isTemposync, bool getIsTemposync(), false, (asBase()));
+    HASMEM(isDeactivated, bool getIsDeactivated(int index), false, (asBase(), index));
 
 #undef HASMEM
 


### PR DESCRIPTION
1. Add a new api getIsDeactivate(index) to the common template API and sifnae it to false
2. Use that in waveshaper to replace the hpOn hpOff params