### PR TITLE
Add a proper tail calculation on the ShortDelay

### DIFF
--- a/include/sst/voice-effects/VoiceEffectCore.h
+++ b/include/sst/voice-effects/VoiceEffectCore.h
@@ -132,12 +132,12 @@ template <typename VFXConfig> struct VoiceEffectTemplateBase : public VFXConfig:
                                    std::declval<typename VFXConfig::BaseClass *>())),
                                float>::value,
                   "Implement getSampleRate");
-    float getSampleRate() { return VFXConfig::getSampleRate(asBase()); }
+    float getSampleRate() const { return VFXConfig::getSampleRate(asBase()); }
     static_assert(std::is_same<decltype(VFXConfig::getSampleRateInv(
                                    std::declval<typename VFXConfig::BaseClass *>())),
                                float>::value,
                   "Implement getSampleRateInv");
-    float getSampleRateInv() { return VFXConfig::getSampleRateInv(asBase()); }
+    float getSampleRateInv() const { return VFXConfig::getSampleRateInv(asBase()); }
 
     /*
      * We have to provide a memory pool

--- a/include/sst/voice-effects/delay/DelaySupport.h
+++ b/include/sst/voice-effects/delay/DelaySupport.h
@@ -57,6 +57,21 @@ struct DelayLineSupport
         }
     }
 
+    template <size_t N> void clearLine()
+    {
+        auto res = std::get<N - shortestN>(linePointers);
+        if (res)
+        {
+            res->clear();
+        }
+    }
+
+    template <size_t N> bool hasLinePointer()
+    {
+        auto res = std::get<N - shortestN>(linePointers);
+        return res != nullptr;
+    }
+
     template <size_t N> LineN<N> *getLinePointer()
     {
         auto res = std::get<N - shortestN>(linePointers);
@@ -65,7 +80,7 @@ struct DelayLineSupport
     }
 
   protected:
-    uint8_t *lineBuffer;
+    uint8_t *lineBuffer{nullptr};
 
     std::tuple<LineN<12> *, LineN<13> *, LineN<14> *, LineN<15> *, LineN<16> *, LineN<17> *,
                LineN<18> *, LineN<19> *, LineN<20> *>


### PR DESCRIPTION
This commit does a few things

1. Adds a propert tail on ShortDelay
2. Makes it so if ShortDelay is initialized multiple times it doesn't leak its line
3. Adds some consts in places where you can tolerate them

Addresses https://github.com/surge-synthesizer/shortcircuit-xt/issues/852