### PR TITLE
"Lift" bus effects into the voice effect space

### DIFF
--- a/include/sst/effects/EffectCore.h
+++ b/include/sst/effects/EffectCore.h
@@ -265,6 +265,14 @@ template <typename FXConfig> struct EffectTemplateBase : public FXConfig::BaseCl
             return res.asPercentBipolar().withRange(-2.f, 2.f).withDefault(1.f);
     }
 
+    int getDefaultWidth() const
+    {
+        if constexpr (!useLinearWidth())
+            return 0.f;
+        else
+            return 1.f;
+    }
+
     template <typename Smoother> void setWidthTarget(Smoother &width, int idx, float scale = 1.f)
     {
         if constexpr (!useLinearWidth())

--- a/include/sst/voice-effects/lifted_bus_effects/FXConfigFromVFXConfig.h
+++ b/include/sst/voice-effects/lifted_bus_effects/FXConfigFromVFXConfig.h
@@ -1,0 +1,121 @@
+/*
+ * sst-effects - an open source library of audio effects
+ * built by Surge Synth Team.
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-effects is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * The majority of these effects at initiation were factored from
+ * Surge XT, and so git history prior to April 2023 is found in the
+ * surge repo, https://github.com/surge-synthesizer/surge
+ *
+ * All source in sst-effects available at
+ * https://github.com/surge-synthesizer/sst-effects
+ */
+
+#ifndef INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_FXCONFIGFROMVFXCONFIG_H
+#define INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_FXCONFIGFROMVFXCONFIG_H
+
+#include "../VoiceEffectCore.h"
+#include "sst/basic-blocks/mechanics/block-ops.h"
+
+namespace sst::voice_effects::liftbus
+{
+
+namespace mech = sst::basic_blocks::mechanics;
+template <typename BASE> struct FXConfigFromVFXConfig
+{
+    using GlobalStorage = BASE;
+    using EffectStorage = BASE;
+    using BiquadAdapter = BASE;
+    using ValueStorage = float;
+
+    struct BaseClass
+    {
+        BaseClass(GlobalStorage *, EffectStorage *, ValueStorage *) {}
+    };
+
+    static constexpr size_t blockSize{BASE::config_t::blockSize};
+
+    static inline float floatValueAt(const BaseClass *const e, const ValueStorage *const v, int idx)
+    {
+        return v[idx];
+    }
+    static inline int intValueAt(const BaseClass *const e, const ValueStorage *const v, int idx)
+    {
+        return (int)std::round(v[idx]);
+    }
+
+    static inline float envelopeRateLinear(GlobalStorage *s, float f)
+    {
+        return s->envelope_rate_linear_nowrap(f);
+    }
+
+    static inline float temposyncRatio(GlobalStorage *s, EffectStorage *e, int idx)
+    {
+        return s->getTempoSyncRatio();
+    }
+
+    static inline bool isDeactivated(EffectStorage *e, int idx) { return false; }
+
+    static inline bool isExtended(EffectStorage *s, int idx) { return false; }
+
+    static inline float rand01(GlobalStorage *s)
+    {
+        assert(false);
+        return (float)rand() / (float)RAND_MAX;
+    }
+
+    static inline double sampleRate(GlobalStorage *s) { return s->getSampleRate(); }
+
+    static inline float noteToPitch(GlobalStorage *s, float p) { return s->equalNoteToPitch(p); }
+    static inline float noteToPitchIgnoringTuning(GlobalStorage *s, float p)
+    {
+        return noteToPitch(s, p);
+    }
+
+    static inline float noteToPitchInv(GlobalStorage *s, float p)
+    {
+        return 1.0 / noteToPitch(s, p);
+    }
+
+    static inline float dbToLinear(GlobalStorage *s, float f) { return s->dbToLinear(f); }
+};
+
+template <typename Inside, typename FX> struct LiftHelper
+{
+    static constexpr size_t memChunkSize{sizeof(FX)};
+    uint8_t *busFXMem{nullptr};
+    FX *busFX{nullptr};
+    Inside *that;
+    LiftHelper(Inside *is) : that(is) { that->preReserveSingleInstancePool(memChunkSize); }
+    ~LiftHelper()
+    {
+        if (busFX)
+        {
+            busFX->~FX();
+            that->returnBlock(busFXMem, memChunkSize);
+        }
+    }
+
+    void init()
+    {
+        if (!busFX)
+        {
+            busFXMem = that->checkoutBlock(memChunkSize);
+            busFX = new (busFXMem) FX(that, that, &(valuesForFX[0]));
+        }
+
+        that->setupValues();
+        busFX->initialize();
+    }
+    float valuesForFX[20];
+};
+
+} // namespace sst::voice_effects::liftbus
+#endif // SHORTCIRCUITXT_FXCONFIGFROMVFXCONFIG_H

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedDelay.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedDelay.h
@@ -1,0 +1,85 @@
+/*
+ * sst-effects - an open source library of audio effects
+ * built by Surge Synth Team.
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-effects is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * The majority of these effects at initiation were factored from
+ * Surge XT, and so git history prior to April 2023 is found in the
+ * surge repo, https://github.com/surge-synthesizer/surge
+ *
+ * All source in sst-effects available at
+ * https://github.com/surge-synthesizer/sst-effects
+ */
+
+#ifndef INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDDELAY_H
+#define INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDDELAY_H
+
+#include "../VoiceEffectCore.h"
+#include "sst/effects/Delay.h"
+#include "sst/basic-blocks/params/ParamMetadata.h"
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "FXConfigFromVFXConfig.h"
+
+namespace sst::voice_effects::liftbus
+{
+
+namespace mech = sst::basic_blocks::mechanics;
+template <typename VFXConfig> struct LiftedDelay : core::VoiceEffectTemplateBase<VFXConfig>
+{
+    static constexpr const char *effectName{"Delay"};
+
+    static constexpr int numFloatParams{8};
+    static constexpr int numIntParams{0};
+
+    using delay_t = sst::effects::delay::Delay<FXConfigFromVFXConfig<LiftedDelay<VFXConfig>>>;
+    LiftHelper<LiftedDelay, delay_t> helper;
+
+    LiftedDelay() : helper(this), core::VoiceEffectTemplateBase<VFXConfig>() {}
+
+    basic_blocks::params::ParamMetaData paramAt(int idx) const
+    {
+        using pmd = basic_blocks::params::ParamMetaData;
+        return helper.busFX->paramAt(idx);
+    }
+
+    void setupValues()
+    {
+        for (int i = 0; i < numFloatParams; ++i)
+        {
+            helper.valuesForFX[i] = this->getFloatParam(i);
+        }
+        helper.valuesForFX[delay_t::dly_width] = helper.busFX->getDefaultWidth();
+
+        helper.valuesForFX[delay_t::dly_reserved] = 0.f;
+        helper.valuesForFX[delay_t::dly_mix] = 1.f;
+        helper.valuesForFX[delay_t::dly_input_channel] = 0.f;
+    }
+
+    void initVoiceEffect() { helper.init(); }
+
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
+
+    size_t tailLength() const
+    {
+        return -1;
+        // return helper.busFX->getRingoutDecay() * VFXConfig::blockSize;
+    }
+
+    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                       float pitch)
+    {
+        setupValues();
+        mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);
+        mech::copy_from_to<VFXConfig::blockSize>(datainR, dataoutR);
+        helper.busFX->processBlock(dataoutL, dataoutR);
+    }
+};
+} // namespace sst::voice_effects::liftbus
+#endif // SHORTCIRCUITXT_LIFTEDREVERB2_H

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedFlanger.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedFlanger.h
@@ -1,0 +1,91 @@
+/*
+ * sst-effects - an open source library of audio effects
+ * built by Surge Synth Team.
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-effects is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * The majority of these effects at initiation were factored from
+ * Surge XT, and so git history prior to April 2023 is found in the
+ * surge repo, https://github.com/surge-synthesizer/surge
+ *
+ * All source in sst-effects available at
+ * https://github.com/surge-synthesizer/sst-effects
+ */
+
+#ifndef INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDFLANGER_H
+#define INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDFLANGER_H
+
+#include "../VoiceEffectCore.h"
+#include "sst/effects/Flanger.h"
+#include "sst/basic-blocks/params/ParamMetadata.h"
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "FXConfigFromVFXConfig.h"
+
+namespace sst::voice_effects::liftbus
+{
+
+namespace mech = sst::basic_blocks::mechanics;
+template <typename VFXConfig> struct LiftedFlanger : core::VoiceEffectTemplateBase<VFXConfig>
+{
+    static constexpr const char *effectName{"Reverb1"};
+
+    static constexpr int numFloatParams{7};
+    static constexpr int numIntParams{2};
+
+    using flanger_t =
+        sst::effects::flanger::Flanger<FXConfigFromVFXConfig<LiftedFlanger<VFXConfig>>>;
+    LiftHelper<LiftedFlanger, flanger_t> helper;
+
+    LiftedFlanger() : helper(this), core::VoiceEffectTemplateBase<VFXConfig>() {}
+
+    // turns out the two ints are first making this easy
+    basic_blocks::params::ParamMetaData paramAt(int idx) const
+    {
+        using pmd = basic_blocks::params::ParamMetaData;
+
+        return helper.busFX->paramAt(idx + 2);
+    }
+
+    basic_blocks::params::ParamMetaData intParamAt(int idx) const
+    {
+        return helper.busFX->paramAt(idx);
+    }
+
+    void initVoiceEffect() { helper.init(); }
+
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
+
+    size_t tailLength() const { return helper.busFX->getRingoutDecay() * VFXConfig::blockSize; }
+
+    void setupValues()
+    {
+        for (int i = 0; i < numFloatParams; ++i)
+        {
+            helper.valuesForFX[i + 2] = this->getFloatParam(i);
+        }
+        for (int i = 0; i < numIntParams; ++i)
+        {
+            helper.valuesForFX[i] = this->getIntParam(i);
+        }
+
+        helper.valuesForFX[flanger_t::fl_mix] = 1.0;
+        helper.valuesForFX[flanger_t::fl_width] = helper.busFX->getDefaultWidth();
+    }
+
+    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                       float pitch)
+    {
+        setupValues();
+        mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);
+        mech::copy_from_to<VFXConfig::blockSize>(datainR, dataoutR);
+        helper.busFX->processBlock(dataoutL, dataoutR);
+    }
+};
+} // namespace sst::voice_effects::liftbus
+#endif // SHORTCIRCUITXT_LIFTEDREVERB2_H

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedReverb1.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedReverb1.h
@@ -1,0 +1,91 @@
+/*
+ * sst-effects - an open source library of audio effects
+ * built by Surge Synth Team.
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-effects is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * The majority of these effects at initiation were factored from
+ * Surge XT, and so git history prior to April 2023 is found in the
+ * surge repo, https://github.com/surge-synthesizer/surge
+ *
+ * All source in sst-effects available at
+ * https://github.com/surge-synthesizer/sst-effects
+ */
+
+#ifndef INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDREVERB1_H
+#define INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDREVERB1_H
+
+#include "../VoiceEffectCore.h"
+#include "sst/effects/Reverb1.h"
+#include "sst/basic-blocks/params/ParamMetadata.h"
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "FXConfigFromVFXConfig.h"
+
+namespace sst::voice_effects::liftbus
+{
+
+namespace mech = sst::basic_blocks::mechanics;
+template <typename VFXConfig> struct LiftedReverb1 : core::VoiceEffectTemplateBase<VFXConfig>
+{
+    static constexpr const char *effectName{"Reverb1"};
+
+    static constexpr int numFloatParams{8};
+    static constexpr int numIntParams{1};
+
+    using reverb1_t =
+        sst::effects::reverb1::Reverb1<FXConfigFromVFXConfig<LiftedReverb1<VFXConfig>>>;
+    LiftHelper<LiftedReverb1, reverb1_t> helper;
+
+    LiftedReverb1() : helper(this), core::VoiceEffectTemplateBase<VFXConfig>() {}
+
+    basic_blocks::params::ParamMetaData paramAt(int idx) const
+    {
+        using pmd = basic_blocks::params::ParamMetaData;
+        auto udx = idx;
+        if (idx > 0) // we skip shape
+            udx = idx + 1;
+        return helper.busFX->paramAt(udx);
+    }
+
+    basic_blocks::params::ParamMetaData intParamAt(int idx) const
+    {
+        return helper.busFX->paramAt(reverb1_t::rev1_shape);
+    }
+
+    void initVoiceEffect() { helper.init(); }
+
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
+
+    size_t tailLength() const { return helper.busFX->getRingoutDecay() * VFXConfig::blockSize; }
+
+    void setupValues()
+    {
+        for (int i = 0; i < numFloatParams; ++i)
+        {
+            auto udx = i;
+            if (i > 0) // we skip shape
+                udx = i + 1;
+            helper.valuesForFX[udx] = this->getFloatParam(i);
+        }
+        helper.valuesForFX[reverb1_t::rev1_shape] = this->getIntParam(0);
+
+        helper.valuesForFX[reverb1_t::rev1_mix] = 1.0;
+        helper.valuesForFX[reverb1_t::rev1_width] = helper.busFX->getDefaultWidth();
+    }
+    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                       float pitch)
+    {
+        setupValues();
+        mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);
+        mech::copy_from_to<VFXConfig::blockSize>(datainR, dataoutR);
+        helper.busFX->processBlock(dataoutL, dataoutR);
+    }
+};
+} // namespace sst::voice_effects::liftbus
+#endif // SHORTCIRCUITXT_LIFTEDREVERB2_H

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedReverb2.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedReverb2.h
@@ -1,0 +1,78 @@
+/*
+ * sst-effects - an open source library of audio effects
+ * built by Surge Synth Team.
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-effects is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * The majority of these effects at initiation were factored from
+ * Surge XT, and so git history prior to April 2023 is found in the
+ * surge repo, https://github.com/surge-synthesizer/surge
+ *
+ * All source in sst-effects available at
+ * https://github.com/surge-synthesizer/sst-effects
+ */
+
+#ifndef INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDREVERB2_H
+#define INCLUDE_SST_VOICE_EFFECTS_LIFTED_BUS_EFFECTS_LIFTEDREVERB2_H
+
+#include "../VoiceEffectCore.h"
+#include "sst/effects/Reverb2.h"
+#include "sst/basic-blocks/params/ParamMetadata.h"
+#include "sst/basic-blocks/mechanics/block-ops.h"
+#include "FXConfigFromVFXConfig.h"
+
+namespace sst::voice_effects::liftbus
+{
+
+namespace mech = sst::basic_blocks::mechanics;
+template <typename VFXConfig> struct LiftedReverb2 : core::VoiceEffectTemplateBase<VFXConfig>
+{
+    static constexpr const char *effectName{"Reverb2"};
+
+    static constexpr int numFloatParams{8};
+    static constexpr int numIntParams{0};
+
+    using reverb2_t =
+        sst::effects::reverb2::Reverb2<FXConfigFromVFXConfig<LiftedReverb2<VFXConfig>>>;
+    LiftHelper<LiftedReverb2, reverb2_t> helper;
+
+    LiftedReverb2() : helper(this), core::VoiceEffectTemplateBase<VFXConfig>() {}
+
+    basic_blocks::params::ParamMetaData paramAt(int idx) const
+    {
+        using pmd = basic_blocks::params::ParamMetaData;
+        return helper.busFX->paramAt(idx);
+    }
+
+    void initVoiceEffect() { helper.init(); }
+
+    void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
+
+    size_t tailLength() const { return helper.busFX->getRingoutDecay() * VFXConfig::blockSize; }
+
+    void setupValues()
+    {
+        for (int i = 0; i < numFloatParams; ++i)
+        {
+            helper.valuesForFX[i] = this->getFloatParam(i);
+        }
+        helper.valuesForFX[reverb2_t::rev2_width] = helper.busFX->getDefaultWidth();
+        helper.valuesForFX[reverb2_t::rev2_mix] = 1.f;
+    }
+    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
+                       float pitch)
+    {
+        setupValues();
+        mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);
+        mech::copy_from_to<VFXConfig::blockSize>(datainR, dataoutR);
+        helper.busFX->processBlock(dataoutL, dataoutR);
+    }
+};
+} // namespace sst::voice_effects::liftbus
+#endif // SHORTCIRCUITXT_LIFTEDREVERB2_H

--- a/include/sst/voice-effects/modulation/ShepardPhaser.h
+++ b/include/sst/voice-effects/modulation/ShepardPhaser.h
@@ -18,8 +18,8 @@
  * https://github.com/surge-synthesizer/sst-effects
  */
 
-#ifndef INCLUDE_SST_VOICE_EFFECTS_MODULATION_SHEPARD_PHASER_H
-#define INCLUDE_SST_VOICE_EFFECTS_MODULATION_SHEPARD_PHASER_H
+#ifndef INCLUDE_SST_VOICE_EFFECTS_MODULATION_SHEPARDPHASER_H
+#define INCLUDE_SST_VOICE_EFFECTS_MODULATION_SHEPARDPHASER_H
 
 #include "sst/basic-blocks/params/ParamMetadata.h"
 #include "../VoiceEffectCore.h"

--- a/tests/create-voice-effect.cpp
+++ b/tests/create-voice-effect.cpp
@@ -48,6 +48,11 @@
 #include "sst/voice-effects/generator/TiltNoise.h"
 #include "sst/voice-effects/modulation/NoiseAM.h"
 
+#include "sst/voice-effects/lifted_bus_effects/LiftedReverb1.h"
+#include "sst/voice-effects/lifted_bus_effects/LiftedReverb2.h"
+#include "sst/voice-effects/lifted_bus_effects/LiftedDelay.h"
+#include "sst/voice-effects/lifted_bus_effects/LiftedFlanger.h"
+
 struct VTestConfig
 {
     struct BaseClass
@@ -68,6 +73,7 @@ struct VTestConfig
     static float getSampleRateInv(const BaseClass *) { return 1.0 / 48000.f; }
 
     static void preReservePool(BaseClass *, size_t) {}
+    static void preReserveSingleInstancePool(BaseClass *, size_t) {}
     static uint8_t *checkoutBlock(BaseClass *, size_t) { return nullptr; }
     static void returnBlock(BaseClass *, uint8_t *, size_t) {}
 };
@@ -180,4 +186,21 @@ TEST_CASE("Can Create Voice FX")
         VTester<sst::voice_effects::generator::TiltNoise<VTestConfig>>::TestVFX();
     }
     SECTION("Phaser") { VTester<sst::voice_effects::modulation::NoiseAM<VTestConfig>>::TestVFX(); }
+
+    SECTION("Lifted Reverb 1")
+    {
+        VTester<sst::voice_effects::liftbus::LiftedReverb1<VTestConfig>>::TestVFX();
+    }
+    SECTION("Lifted Reverb 2")
+    {
+        VTester<sst::voice_effects::liftbus::LiftedReverb2<VTestConfig>>::TestVFX();
+    }
+    SECTION("Lifted Delay")
+    {
+        VTester<sst::voice_effects::liftbus::LiftedDelay<VTestConfig>>::TestVFX();
+    }
+    SECTION("Lifted Flanger")
+    {
+        VTester<sst::voice_effects::liftbus::LiftedFlanger<VTestConfig>>::TestVFX();
+    }
 }


### PR DESCRIPTION
This commit starts giving us the tools needed to
"lift" a bus effect into a voice effect, with all the pros and cons that entails. Including

- New memroy pool API
- Lift of Delay, R1 and 2, and flanger
- Variety of associated other changes

A few things don't work well now

- Delay tail calculation is garbage. Flanger is unchecked
- Temposync support not working yet.