### PR TITLE
A const-only diff in voice effects

### DIFF
--- a/include/sst/effects-shared/TreemonsterCore.h
+++ b/include/sst/effects-shared/TreemonsterCore.h
@@ -71,7 +71,8 @@ struct TreemonsterCore : public BaseClass
         mix.set_blocksize(FXConfig::blockSize);
     }
 
-    void processWithoutMixOrWith(float *dataL, float *dataR, float *wetL, float *wetR);
+    void processWithoutMixOrWith(const float *const dataL, const float *const dataR, float *wetL,
+                                 float *wetR);
 
     void processWithMixAndWidth(float *dataL, float *dataR)
     {
@@ -168,9 +169,8 @@ inline void TreemonsterCore<BaseClass, BiquadType, addHPLP>::setvars(bool init)
     }
 }
 template <typename BaseClass, typename BiquadType, bool addHPLP>
-void TreemonsterCore<BaseClass, BiquadType, addHPLP>::processWithoutMixOrWith(float *dataL,
-                                                                              float *dataR,
-                                                                              float *L, float *R)
+void TreemonsterCore<BaseClass, BiquadType, addHPLP>::processWithoutMixOrWith(
+    const float *const dataL, const float *const dataR, float *L, float *R)
 {
     static constexpr double MIDI_0_FREQ = 8.17579891564371; // or 440.0 * pow( 2.0, - (69.0/12.0 ) )
 

--- a/include/sst/voice-effects/delay/Chorus.h
+++ b/include/sst/voice-effects/delay/Chorus.h
@@ -206,8 +206,8 @@ template <typename VFXConfig> struct Chorus : core::VoiceEffectTemplateBase<VFXC
     bool phaseSet = false;
 
     template <typename T>
-    void stereoImpl(const std::array<T *, 2> &lines, float *datainL, float *datainR,
-                    float *dataoutL, float *dataoutR)
+    void stereoImpl(const std::array<T *, 2> &lines, const float *const datainL,
+                    const float *const datainR, float *dataoutL, float *dataoutR)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -286,7 +286,7 @@ template <typename VFXConfig> struct Chorus : core::VoiceEffectTemplateBase<VFXC
         }
     }
 
-    template <typename T> void monoImpl(T *line, float *datainL, float *dataoutL)
+    template <typename T> void monoImpl(T *line, const float *const datainL, float *dataoutL)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -351,8 +351,8 @@ template <typename VFXConfig> struct Chorus : core::VoiceEffectTemplateBase<VFXC
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         if (isShort)
         {
@@ -368,12 +368,13 @@ template <typename VFXConfig> struct Chorus : core::VoiceEffectTemplateBase<VFXC
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         if (isShort)
         {

--- a/include/sst/voice-effects/delay/Microgate.h
+++ b/include/sst/voice-effects/delay/Microgate.h
@@ -97,8 +97,8 @@ template <typename VFXConfig> struct MicroGate : core::VoiceEffectTemplateBase<V
 
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
 

--- a/include/sst/voice-effects/delay/ShortDelay.h
+++ b/include/sst/voice-effects/delay/ShortDelay.h
@@ -191,8 +191,8 @@ template <typename VFXConfig> struct ShortDelay : core::VoiceEffectTemplateBase<
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
     template <typename T>
-    void stereoImpl(const std::array<T *, 2> &lines, float *datainL, float *datainR,
-                    float *dataoutL, float *dataoutR)
+    void stereoImpl(const std::array<T *, 2> &lines, const float *const datainL,
+                    const float *const datainR, float *dataoutL, float *dataoutR)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -264,7 +264,7 @@ template <typename VFXConfig> struct ShortDelay : core::VoiceEffectTemplateBase<
         }
     }
 
-    template <typename T> void monoImpl(T *line, float *datainL, float *dataoutL)
+    template <typename T> void monoImpl(T *line, const float *const datainL, float *dataoutL)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -313,8 +313,8 @@ template <typename VFXConfig> struct ShortDelay : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         if (isShort)
         {
@@ -330,7 +330,8 @@ template <typename VFXConfig> struct ShortDelay : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processMonoToStereo(float *datain, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datain, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         if (isShort)
         {
@@ -346,7 +347,7 @@ template <typename VFXConfig> struct ShortDelay : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processMonoToMono(float *datain, float *dataout, float pitch)
+    void processMonoToMono(const float *const datain, float *dataout, float pitch)
     {
         if (isShort)
         {

--- a/include/sst/voice-effects/delay/StringResonator.h
+++ b/include/sst/voice-effects/delay/StringResonator.h
@@ -245,8 +245,8 @@ template <typename VFXConfig> struct StringResonator : core::VoiceEffectTemplate
     }
 
     template <typename T>
-    void stereoDualString(const std::array<T *, 2> &lines, float *datainL, float *datainR,
-                          float *dataoutL, float *dataoutR, float pitch)
+    void stereoDualString(const std::array<T *, 2> &lines, const float *const datainL,
+                          const float *const datainR, float *dataoutL, float *dataoutR, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -360,8 +360,8 @@ template <typename VFXConfig> struct StringResonator : core::VoiceEffectTemplate
     }
 
     template <typename T>
-    void stereoSingleString(T *line, float *datainL, float *datainR, float *dataoutL,
-                            float *dataoutR, float pitch)
+    void stereoSingleString(T *line, const float *const datainL, const float *const datainR,
+                            float *dataoutL, float *dataoutR, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -446,8 +446,8 @@ template <typename VFXConfig> struct StringResonator : core::VoiceEffectTemplate
     }
 
     template <typename T>
-    void monoDualString(const std::array<T *, 2> &lines, float *datainL, float *dataoutL,
-                        float pitch)
+    void monoDualString(const std::array<T *, 2> &lines, const float *const datainL,
+                        float *dataoutL, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -529,7 +529,7 @@ template <typename VFXConfig> struct StringResonator : core::VoiceEffectTemplate
     }
 
     template <typename T>
-    void monoSingleString(T *line, float *datainL, float *dataoutL, float pitch)
+    void monoSingleString(T *line, const float *const datainL, float *dataoutL, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -660,8 +660,8 @@ template <typename VFXConfig> struct StringResonator : core::VoiceEffectTemplate
         return 0;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         if (this->getIntParam(ipDualString == true))
         {
@@ -694,12 +694,13 @@ template <typename VFXConfig> struct StringResonator : core::VoiceEffectTemplate
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         if (this->getIntParam(ipDualString == true))
         {

--- a/include/sst/voice-effects/delay/Widener.h
+++ b/include/sst/voice-effects/delay/Widener.h
@@ -118,8 +118,8 @@ template <typename VFXConfig> struct Widener : core::VoiceEffectTemplateBase<VFX
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
     template <typename Line>
-    void processOntoLine(Line *line, float *datainL, float *datainR, float *dataoutL,
-                         float *dataoutR, float pitch)
+    void processOntoLine(Line *line, const float *const datainL, const float *const datainR,
+                         float *dataoutL, float *dataoutR, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
         namespace sdsp = sst::basic_blocks::dsp;
@@ -154,8 +154,8 @@ template <typename VFXConfig> struct Widener : core::VoiceEffectTemplateBase<VFX
         sdsp::decodeMS<VFXConfig::blockSize>(mid, side, dataoutL, dataoutR);
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         if (isShort)
         {

--- a/include/sst/voice-effects/distortion/BitCrusher.h
+++ b/include/sst/voice-effects/distortion/BitCrusher.h
@@ -117,8 +117,8 @@ template <typename VFXConfig> struct BitCrusher : core::VoiceEffectTemplateBase<
 
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         bool filterSwitch = this->getIntParam(ipFilterSwitch);
         int filtMode = this->getIntParam(ipFilterMode);

--- a/include/sst/voice-effects/distortion/Slewer.h
+++ b/include/sst/voice-effects/distortion/Slewer.h
@@ -117,8 +117,8 @@ template <typename VFXConfig> struct Slewer : core::VoiceEffectTemplateBase<VFXC
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         calc_coeffs();
         float rate alignas(16)[VFXConfig::blockSize];
@@ -144,7 +144,7 @@ template <typename VFXConfig> struct Slewer : core::VoiceEffectTemplateBase<VFXC
         bq[1].process_block_to(dataoutL, dataoutR, dataoutL, dataoutR);
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         calc_coeffs();
         float rate alignas(16)[VFXConfig::blockSize];

--- a/include/sst/voice-effects/distortion/TreeMonster.h
+++ b/include/sst/voice-effects/distortion/TreeMonster.h
@@ -91,8 +91,8 @@ template <typename VFXConfig> struct TreeMonster : core::VoiceEffectTemplateBase
     void initVoiceEffect() { coreProc.initialize(); }
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         coreProc.processWithoutMixOrWith(datainL, datainR, dataoutL, dataoutR);
     }

--- a/include/sst/voice-effects/dynamics/AutoWah.h
+++ b/include/sst/voice-effects/dynamics/AutoWah.h
@@ -147,8 +147,8 @@ template <typename VFXConfig> struct AutoWah : core::VoiceEffectTemplateBase<VFX
         R = R - 4.0 / 27.0 * R * R * R;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto sens = 1 + -1 * this->getFloatParam(fpSens);
         sens *= sens;

--- a/include/sst/voice-effects/dynamics/Compressor.h
+++ b/include/sst/voice-effects/dynamics/Compressor.h
@@ -215,8 +215,8 @@ template <typename VFXConfig> struct Compressor : core::VoiceEffectTemplateBase<
         return z;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto makeup = decibelsToAmplitude(this->getFloatParam(fpMakeUp));
         gainLerp.set_target(makeup);
@@ -271,7 +271,7 @@ template <typename VFXConfig> struct Compressor : core::VoiceEffectTemplateBase<
         gainLerp.multiply_2_blocks(dataoutL, dataoutR);
     }
 
-    void processMonoToMono(float *datain, float *dataout, float pitch)
+    void processMonoToMono(const float *const datain, float *dataout, float pitch)
     {
         auto makeup = decibelsToAmplitude(this->getFloatParam(fpMakeUp));
         gainLerp.set_target(makeup);

--- a/include/sst/voice-effects/eq/EqGraphic6Band.h
+++ b/include/sst/voice-effects/eq/EqGraphic6Band.h
@@ -66,12 +66,12 @@ template <typename VFXConfig> struct EqGraphic6Band : core::VoiceEffectTemplateB
     void initVoiceEffect() {}
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         calc_coeffs();
-        float *inL = datainL;
-        float *inR = datainR;
+        auto *inL = datainL;
+        auto *inR = datainR;
         for (int i = 0; i < nBands; ++i)
         {
             mParametric[i].process_block_to(inL, inR, dataoutL, dataoutR);
@@ -80,10 +80,10 @@ template <typename VFXConfig> struct EqGraphic6Band : core::VoiceEffectTemplateB
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         calc_coeffs();
-        float *inL = datainL;
+        auto *inL = datainL;
         for (int i = 0; i < nBands; ++i)
         {
             mParametric[i].process_block_to(inL, dataoutL);

--- a/include/sst/voice-effects/eq/EqNBandParametric.h
+++ b/include/sst/voice-effects/eq/EqNBandParametric.h
@@ -99,12 +99,12 @@ struct EqNBandParametric : core::VoiceEffectTemplateBase<VFXConfig>
     void initVoiceEffect() {}
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         calc_coeffs();
-        float *inL = datainL;
-        float *inR = datainR;
+        auto *inL = datainL;
+        auto *inR = datainR;
         for (int i = 0; i < NBands; ++i)
         {
             mParametric[i].process_block_to(inL, inR, dataoutL, dataoutR);
@@ -113,10 +113,10 @@ struct EqNBandParametric : core::VoiceEffectTemplateBase<VFXConfig>
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         calc_coeffs();
-        float *inL = datainL;
+        auto *inL = datainL;
         for (int i = 0; i < NBands; ++i)
         {
             mParametric[i].process_block_to(inL, dataoutL);

--- a/include/sst/voice-effects/eq/MorphEQ.h
+++ b/include/sst/voice-effects/eq/MorphEQ.h
@@ -292,8 +292,8 @@ template <typename VFXConfig> struct MorphEQ : core::VoiceEffectTemplateBase<VFX
     }
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         calc_coeffs();
         gain.multiply_2_blocks_to(datainL, datainR, dataoutL, dataoutR);
@@ -311,7 +311,7 @@ template <typename VFXConfig> struct MorphEQ : core::VoiceEffectTemplateBase<VFX
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         calc_coeffs();
 

--- a/include/sst/voice-effects/eq/TiltEQ.h
+++ b/include/sst/voice-effects/eq/TiltEQ.h
@@ -97,8 +97,8 @@ template <typename VFXConfig> struct TiltEQ : core::VoiceEffectTemplateBase<VFXC
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         setCoeffs();
         filters[0].template processBlock<VFXConfig::blockSize>(datainL, datainR, dataoutL,
@@ -107,7 +107,7 @@ template <typename VFXConfig> struct TiltEQ : core::VoiceEffectTemplateBase<VFXC
                                                                dataoutR);
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         setCoeffs();
         filters[0].template processBlock<VFXConfig::blockSize>(datainL, dataoutL);

--- a/include/sst/voice-effects/filter/CytomicSVF.h
+++ b/include/sst/voice-effects/filter/CytomicSVF.h
@@ -240,8 +240,8 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         calc_coeffs(pitch);
         cySvf[0].template processBlock<VFXConfig::blockSize>(datainL, datainR, dataoutL, dataoutR);
@@ -252,7 +252,7 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         calc_coeffs(pitch);
         cySvf[0].template processBlock<VFXConfig::blockSize>(datainL, dataoutL);
@@ -262,7 +262,8 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         calc_coeffs(pitch);
         cySvf[0].template processBlock<VFXConfig::blockSize>(datainL, datainL, dataoutL, dataoutR);

--- a/include/sst/voice-effects/filter/SSTFilters.h
+++ b/include/sst/voice-effects/filter/SSTFilters.h
@@ -238,8 +238,8 @@ template <typename VFXConfig> struct SSTFilters : core::VoiceEffectTemplateBase<
         mLastParam = param;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         updateCoefficients(pitch, true);
         if (filterUnitPtr)
@@ -266,7 +266,7 @@ template <typename VFXConfig> struct SSTFilters : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         updateCoefficients(pitch, false);
 

--- a/include/sst/voice-effects/filter/StaticPhaser.h
+++ b/include/sst/voice-effects/filter/StaticPhaser.h
@@ -153,8 +153,8 @@ template <typename VFXConfig> struct StaticPhaser : core::VoiceEffectTemplateBas
     }
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
 
@@ -182,12 +182,13 @@ template <typename VFXConfig> struct StaticPhaser : core::VoiceEffectTemplateBas
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }
 
-    void processMonoToMono(float *dataIn, float *dataOut, float pitch)
+    void processMonoToMono(const float *const dataIn, float *dataOut, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
 

--- a/include/sst/voice-effects/generator/GenCorrelatedNoise.h
+++ b/include/sst/voice-effects/generator/GenCorrelatedNoise.h
@@ -119,8 +119,8 @@ template <typename VFXConfig> struct GenCorrelatedNoise : core::VoiceEffectTempl
         rightOut = midIn - sideIn;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto isStereo = this->getIntParam(ipStereo) != 0;
         if (!isStereo)
@@ -162,7 +162,7 @@ template <typename VFXConfig> struct GenCorrelatedNoise : core::VoiceEffectTempl
         mLevelLerp.multiply_2_blocks(dataoutL, dataoutR);
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         auto levT = std::clamp(this->getFloatParam(fpLevel), 0.f, 1.f);
         levT = levT * levT * levT;
@@ -184,7 +184,8 @@ template <typename VFXConfig> struct GenCorrelatedNoise : core::VoiceEffectTempl
         mLevelLerp.multiply_block(dataoutL);
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }

--- a/include/sst/voice-effects/generator/GenVA.h
+++ b/include/sst/voice-effects/generator/GenVA.h
@@ -149,7 +149,7 @@ template <typename VFXConfig> struct GenVA : core::VoiceEffectTemplateBase<VFXCo
     void initVoiceEffect() {}
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processSine(float *datainL, float *dataoutL, float pitch)
+    void processSine(const float *const datainL, float *dataoutL, float pitch)
     {
         if (keytrackOn)
         {
@@ -175,7 +175,7 @@ template <typename VFXConfig> struct GenVA : core::VoiceEffectTemplateBase<VFXCo
         sLevelLerp.multiply_block(dataoutL);
     }
 
-    void processSaw(float *datainL, float *dataoutL, float pitch)
+    void processSaw(const float *const datainL, float *dataoutL, float pitch)
     {
         auto tune = this->getFloatParam(fpOffset);
         auto lp = this->getFloatParam(fpLowpass);
@@ -206,7 +206,7 @@ template <typename VFXConfig> struct GenVA : core::VoiceEffectTemplateBase<VFXCo
         sLevelLerp.multiply_block(dataoutL);
     }
 
-    void processPulse(float *datainL, float *dataoutL, float pitch)
+    void processPulse(const float *const datainL, float *dataoutL, float pitch)
     {
         mTuneLerp.newValue(this->getFloatParam(fpOffset));
         mWidthLerp.newValue(this->getFloatParam(fpWidth));
@@ -258,7 +258,7 @@ template <typename VFXConfig> struct GenVA : core::VoiceEffectTemplateBase<VFXCo
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         int wave = this->getIntParam(ipWaveform);
         if (wave == 0)
@@ -275,8 +275,8 @@ template <typename VFXConfig> struct GenVA : core::VoiceEffectTemplateBase<VFXCo
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
 
         processMonoToMono(datainL, dataoutL, pitch);

--- a/include/sst/voice-effects/generator/TiltNoise.h
+++ b/include/sst/voice-effects/generator/TiltNoise.h
@@ -144,8 +144,8 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
         rightOut = midIn - sideIn;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         bool stereo = this->getIntParam(ipStereo);
 
@@ -193,7 +193,7 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
         levelLerp.multiply_2_blocks(dataoutL, dataoutR);
     }
 
-    void processMonoToMono(float *datain, float *dataout, float pitch)
+    void processMonoToMono(const float *const datain, float *dataout, float pitch)
     {
         float level = this->getFloatParam(fpLevel);
         level = level * level * level;
@@ -223,7 +223,8 @@ template <typename VFXConfig> struct TiltNoise : core::VoiceEffectTemplateBase<V
         levelLerp.multiply_block(dataout);
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedDelay.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedDelay.h
@@ -72,8 +72,8 @@ template <typename VFXConfig> struct LiftedDelay : core::VoiceEffectTemplateBase
         // return helper.busFX->getRingoutDecay() * VFXConfig::blockSize;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         setupValues();
         mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedFlanger.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedFlanger.h
@@ -78,8 +78,8 @@ template <typename VFXConfig> struct LiftedFlanger : core::VoiceEffectTemplateBa
         helper.valuesForFX[flanger_t::fl_width] = helper.busFX->getDefaultWidth();
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         setupValues();
         mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedReverb1.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedReverb1.h
@@ -78,8 +78,8 @@ template <typename VFXConfig> struct LiftedReverb1 : core::VoiceEffectTemplateBa
         helper.valuesForFX[reverb1_t::rev1_mix] = 1.0;
         helper.valuesForFX[reverb1_t::rev1_width] = helper.busFX->getDefaultWidth();
     }
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         setupValues();
         mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);

--- a/include/sst/voice-effects/lifted_bus_effects/LiftedReverb2.h
+++ b/include/sst/voice-effects/lifted_bus_effects/LiftedReverb2.h
@@ -65,8 +65,8 @@ template <typename VFXConfig> struct LiftedReverb2 : core::VoiceEffectTemplateBa
         helper.valuesForFX[reverb2_t::rev2_width] = helper.busFX->getDefaultWidth();
         helper.valuesForFX[reverb2_t::rev2_mix] = 1.f;
     }
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         setupValues();
         mech::copy_from_to<VFXConfig::blockSize>(datainL, dataoutL);

--- a/include/sst/voice-effects/modulation/FMFilter.h
+++ b/include/sst/voice-effects/modulation/FMFilter.h
@@ -169,8 +169,8 @@ template <typename VFXConfig> struct FMFilter : core::VoiceEffectTemplateBase<VF
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         if (isFirst)
         {
@@ -240,7 +240,7 @@ template <typename VFXConfig> struct FMFilter : core::VoiceEffectTemplateBase<VF
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         if (isFirst)
         {
@@ -299,7 +299,8 @@ template <typename VFXConfig> struct FMFilter : core::VoiceEffectTemplateBase<VF
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }

--- a/include/sst/voice-effects/modulation/FreqShiftMod.h
+++ b/include/sst/voice-effects/modulation/FreqShiftMod.h
@@ -93,8 +93,8 @@ template <typename VFXConfig> struct FreqShiftMod : core::VoiceEffectTemplateBas
     }
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto rate = this->getFloatParam((int)FreqShiftModFloatParams::coarse) +
                     this->getFloatParam((int)FreqShiftModFloatParams::fine);

--- a/include/sst/voice-effects/modulation/NoiseAM.h
+++ b/include/sst/voice-effects/modulation/NoiseAM.h
@@ -192,8 +192,8 @@ template <typename VFXConfig> struct NoiseAM : core::VoiceEffectTemplateBase<VFX
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         bool stereo = this->getIntParam(ipStereo);
         float threshold = this->getFloatParam(fpThreshold);
@@ -270,7 +270,7 @@ template <typename VFXConfig> struct NoiseAM : core::VoiceEffectTemplateBase<VFX
         }
     }
 
-    void processMonoToMono(float *datain, float *dataout, float pitch)
+    void processMonoToMono(const float *const datain, float *dataout, float pitch)
     {
         float threshold = this->getFloatParam(fpThreshold);
         auto depth = this->getFloatParam(fpDepth);
@@ -317,7 +317,8 @@ template <typename VFXConfig> struct NoiseAM : core::VoiceEffectTemplateBase<VFX
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }

--- a/include/sst/voice-effects/modulation/PhaseMod.h
+++ b/include/sst/voice-effects/modulation/PhaseMod.h
@@ -115,8 +115,8 @@ template <typename VFXConfig> struct PhaseMod : core::VoiceEffectTemplateBase<VF
         return 12 * std::log2(ratio);
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         namespace sdsp = sst::basic_blocks::dsp;
 
@@ -168,7 +168,7 @@ template <typename VFXConfig> struct PhaseMod : core::VoiceEffectTemplateBase<VF
         post.process_block_D2(OS[0], OS[1], bs2, dataoutL, dataoutR);
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         namespace sdsp = sst::basic_blocks::dsp;
 

--- a/include/sst/voice-effects/modulation/Phaser.h
+++ b/include/sst/voice-effects/modulation/Phaser.h
@@ -171,8 +171,8 @@ template <typename VFXConfig> struct Phaser : core::VoiceEffectTemplateBase<VFXC
 
     bool phaseSet = false;
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto lfoRate = this->getFloatParam(fpRate);
         auto lfoDepth = this->getFloatParam(fpDepth);
@@ -226,12 +226,13 @@ template <typename VFXConfig> struct Phaser : core::VoiceEffectTemplateBase<VFXC
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }
 
-    void processMonoToMono(float *dataIn, float *dataOut, float pitch)
+    void processMonoToMono(const float *const dataIn, float *dataOut, float pitch)
     {
         auto lfoRate = this->getFloatParam(fpRate);
         auto lfoDepth = this->getFloatParam(fpDepth);

--- a/include/sst/voice-effects/modulation/RingMod.h
+++ b/include/sst/voice-effects/modulation/RingMod.h
@@ -111,8 +111,8 @@ template <typename VFXConfig> struct RingMod : core::VoiceEffectTemplateBase<VFX
         return 12 * std::log2(ratio);
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
 
@@ -130,7 +130,7 @@ template <typename VFXConfig> struct RingMod : core::VoiceEffectTemplateBase<VFX
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         namespace mech = sst::basic_blocks::mechanics;
         auto pt = this->getFloatParam(fpCarrierFrequency) + (keytrackOn ? pitch : 0);

--- a/include/sst/voice-effects/modulation/ShepardPhaser.h
+++ b/include/sst/voice-effects/modulation/ShepardPhaser.h
@@ -124,8 +124,8 @@ template <typename VFXConfig> struct ShepardPhaser : core::VoiceEffectTemplateBa
         return res * .5 + .5;
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto stereo = this->getIntParam(ipStereo);
         auto range = std::clamp(this->getFloatParam(fpEndFreq), -60.f, 70.f) -
@@ -256,7 +256,7 @@ template <typename VFXConfig> struct ShepardPhaser : core::VoiceEffectTemplateBa
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         auto range = std::clamp(this->getFloatParam(fpEndFreq), -60.f, 70.f) -
                      std::clamp(this->getFloatParam(fpStartFreq), -60.f, 70.f);
@@ -320,7 +320,8 @@ template <typename VFXConfig> struct ShepardPhaser : core::VoiceEffectTemplateBa
         }
     }
 
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);
     }

--- a/include/sst/voice-effects/modulation/Tremolo.h
+++ b/include/sst/voice-effects/modulation/Tremolo.h
@@ -185,8 +185,8 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
      without the filters or the stereo or both.
     */
 
-    void harmonicStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                        float pitch)
+    void harmonicStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                        float *dataoutR, float pitch)
     {
         // Bring in the various params.
         auto lfoRate = this->getFloatParam(fpRate);
@@ -304,8 +304,8 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
      so I separated it. Now the branches are in the process functions further down instead.
      */
 
-    void standardStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                        float pitch)
+    void standardStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                        float *dataoutR, float pitch)
     {
         auto lfoRate = this->getFloatParam(fpRate);
         auto lfoDepth = this->getFloatParam(fpDepth);
@@ -349,7 +349,7 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
         lfoLerp[1].multiply_block(dataoutR);
     }
 
-    void harmonicMono(float *datain, float *dataout, float pitch)
+    void harmonicMono(const float *const datain, float *dataout, float pitch)
     {
         auto lfoRate = this->getFloatParam(fpRate);
         auto lfoDepth = this->getFloatParam(fpDepth);
@@ -414,7 +414,7 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
         sst::basic_blocks::mechanics::add_block<VFXConfig::blockSize>(LP, HP, dataout);
     }
 
-    void standardMono(float *datain, float *dataout, float pitch)
+    void standardMono(const float *const datain, float *dataout, float pitch)
     {
         auto lfoRate = this->getFloatParam(fpRate);
         auto lfoDepth = this->getFloatParam(fpDepth);
@@ -451,8 +451,8 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
      When starting a voice, the host will call one of the following functions.
      This first one gets called if incoming audio is Stereo...
     */
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         if (this->getIntParam(ipHarmonic) == true)
         {
@@ -468,7 +468,7 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
     }
 
     // ...this second one if incoming audio is Mono...
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         if (this->getIntParam(ipHarmonic) == true)
         {
@@ -483,7 +483,8 @@ template <typename VFXConfig> struct Tremolo : core::VoiceEffectTemplateBase<VFX
     }
 
     // ...and this last one if the input is Mono, but the user asked for stereo modulation.
-    void processMonoToStereo(float *datainL, float *dataoutL, float *dataoutR, float pitch)
+    void processMonoToStereo(const float *const datainL, float *dataoutL, float *dataoutR,
+                             float pitch)
     {
         // which in turn simply copies the mono audio and calls the stereo one with the copies.
         processStereo(datainL, datainL, dataoutL, dataoutR, pitch);

--- a/include/sst/voice-effects/utilities/GainMatrix.h
+++ b/include/sst/voice-effects/utilities/GainMatrix.h
@@ -76,8 +76,8 @@ template <typename VFXConfig> struct GainMatrix : core::VoiceEffectTemplateBase<
 
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
 
         llLerp.set_target(this->getFloatParam(fpLeftToLeft));

--- a/include/sst/voice-effects/utilities/StereoTool.h
+++ b/include/sst/voice-effects/utilities/StereoTool.h
@@ -76,8 +76,8 @@ template <typename VFXConfig> struct StereoTool : core::VoiceEffectTemplateBase<
 
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
 
         rotLerp.set_target(this->getFloatParam(fpRotation));

--- a/include/sst/voice-effects/utilities/VolumeAndPan.h
+++ b/include/sst/voice-effects/utilities/VolumeAndPan.h
@@ -82,8 +82,8 @@ template <typename VFXConfig> struct VolumeAndPan : core::VoiceEffectTemplateBas
 
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         auto pan = (this->getFloatParam(fpPan) + 1) / 2;
         basic_blocks::dsp::pan_laws::panmatrix_t pmat{1, 1, 0, 0};

--- a/include/sst/voice-effects/waveshaper/WaveShaper.h
+++ b/include/sst/voice-effects/waveshaper/WaveShaper.h
@@ -135,7 +135,8 @@ template <typename VFXConfig> struct WaveShaper : core::VoiceEffectTemplateBase<
     void initVoiceEffectParams() { this->initToParamMetadataDefault(this); }
 
     template <bool stereo>
-    void processInternal(float *datainL, float *datainR, float *dataoutL, float *dataoutR)
+    void processInternal(const float *const datainL, const float *const datainR, float *dataoutL,
+                         float *dataoutR)
     {
         // Todo: Smooth
         auto drv = this->dbToLinear(this->getFloatParam((int)WaveShaperFloatParams::drive));
@@ -211,8 +212,8 @@ template <typename VFXConfig> struct WaveShaper : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processStereo(float *datainL, float *datainR, float *dataoutL, float *dataoutR,
-                       float pitch)
+    void processStereo(const float *const datainL, const float *const datainR, float *dataoutL,
+                       float *dataoutR, float pitch)
     {
         bool hpActive = !this->getIsDeactivated((int)WaveShaperFloatParams::highpass);
         bool lpActive = !this->getIsDeactivated((int)WaveShaperFloatParams::lowpass);
@@ -249,7 +250,7 @@ template <typename VFXConfig> struct WaveShaper : core::VoiceEffectTemplateBase<
         }
     }
 
-    void processMonoToMono(float *datainL, float *dataoutL, float pitch)
+    void processMonoToMono(const float *const datainL, float *dataoutL, float pitch)
     {
         bool hpActive = !this->getIsDeactivated((int)WaveShaperFloatParams::highpass);
         bool lpActive = !this->getIsDeactivated((int)WaveShaperFloatParams::lowpass);


### PR DESCRIPTION
processStereo goes from float*, float * to const float *const, const float *const as first argument pair, and similarly with mono and so forth in voice effects