### PR TITLE
Increased range for filter keytrack offsets

### DIFF
--- a/include/sst/voice-effects/filter/CytomicSVF.h
+++ b/include/sst/voice-effects/filter/CytomicSVF.h
@@ -83,7 +83,7 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(std::string("Offset") + (stereo ? " L" : ""))
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");
@@ -98,7 +98,7 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(!stereo ? std::string() : "Offset R")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/filter/SSTFilters.h
+++ b/include/sst/voice-effects/filter/SSTFilters.h
@@ -86,7 +86,7 @@ template <typename VFXConfig> struct SSTFilters : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName("Offset")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/filter/StaticPhaser.h
+++ b/include/sst/voice-effects/filter/StaticPhaser.h
@@ -101,7 +101,7 @@ template <typename VFXConfig> struct StaticPhaser : core::VoiceEffectTemplateBas
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(std::string("Offset L") + (stereo ? " L" : ""))
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");
@@ -116,7 +116,7 @@ template <typename VFXConfig> struct StaticPhaser : core::VoiceEffectTemplateBas
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(!stereo ? std::string() : "Offset R")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");
@@ -130,7 +130,7 @@ template <typename VFXConfig> struct StaticPhaser : core::VoiceEffectTemplateBas
         case fpSpacing:
             return pmd()
                 .asFloat()
-                .withRange(-48, 48)
+                .withRange(-48, 96)
                 .withDefault(12)
                 .withName("Spacing")
                 .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/filter/SurgeBiquads.h
+++ b/include/sst/voice-effects/filter/SurgeBiquads.h
@@ -72,7 +72,7 @@ template <typename VFXConfig> struct SurgeBiquads : core::VoiceEffectTemplateBas
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName("Offset")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");


### PR DESCRIPTION
In light of limited upward ranges for keytracking filters combined with no customization of root key at this time...feedback is welcome, both over the underlying idea and whether the edited range is now appropriate.

P.S. Just realized I forgot to make a separate branch for this in my fork. Oh, well...