### PR TITLE
Update keytrack ranges

### DIFF
--- a/include/sst/voice-effects/distortion/BitCrusher.h
+++ b/include/sst/voice-effects/distortion/BitCrusher.h
@@ -82,7 +82,7 @@ template <typename VFXConfig> struct BitCrusher : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(0, 96)
+                    .withRange(-48, 96)
                     .withName("Cutoff Offset")
                     .withDefault(96)
                     .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/dynamics/AutoWah.h
+++ b/include/sst/voice-effects/dynamics/AutoWah.h
@@ -91,7 +91,7 @@ template <typename VFXConfig> struct AutoWah : core::VoiceEffectTemplateBase<VFX
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName("Freq Offset")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/filter/CytomicSVF.h
+++ b/include/sst/voice-effects/filter/CytomicSVF.h
@@ -83,7 +83,7 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(std::string("Offset") + (stereo ? " L" : ""))
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");
@@ -98,7 +98,7 @@ template <typename VFXConfig> struct CytomicSVF : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(!stereo ? std::string() : "Offset R")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/filter/SSTFilters.h
+++ b/include/sst/voice-effects/filter/SSTFilters.h
@@ -86,7 +86,7 @@ template <typename VFXConfig> struct SSTFilters : core::VoiceEffectTemplateBase<
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName("Offset")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");

--- a/include/sst/voice-effects/modulation/FMFilter.h
+++ b/include/sst/voice-effects/modulation/FMFilter.h
@@ -68,7 +68,7 @@ template <typename VFXConfig> struct FMFilter : core::VoiceEffectTemplateBase<VF
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(std::string("Offset") + (stereo ? " L" : ""))
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");
@@ -82,7 +82,7 @@ template <typename VFXConfig> struct FMFilter : core::VoiceEffectTemplateBase<VF
             {
                 return pmd()
                     .asFloat()
-                    .withRange(-48, 48)
+                    .withRange(-48, 96)
                     .withName(!stereo ? std::string() : "Offset R")
                     .withDefault(0)
                     .withLinearScaleFormatting("semitones");


### PR DESCRIPTION
Allow keytrack filters to go 8 octaves up. 4 was a bit stingy. Thanks @PythonBlue