### PR TITLE
Linear Width with associated boost

### DIFF
--- a/include/sst/effects-shared/WidthProvider.h
+++ b/include/sst/effects-shared/WidthProvider.h
@@ -1,0 +1,86 @@
+/*
+ * sst-effects - an open source library of audio effects
+ * built by Surge Synth Team.
+ *
+ * Copyright 2018-2023, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-effects is released under the GNU General Public Licence v3
+ * or later (GPL-3.0-or-later). The license is found in the "LICENSE"
+ * file in the root of this repository, or at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * The majority of these effects at initiation were factored from
+ * Surge XT, and so git history prior to April 2023 is found in the
+ * surge repo, https://github.com/surge-synthesizer/surge
+ *
+ * All source in sst-effects available at
+ * https://github.com/surge-synthesizer/sst-effects
+ */
+
+#ifndef INCLUDE_SST_EFFECTS_SHARED_WIDTHPROVIDER_H
+#define INCLUDE_SST_EFFECTS_SHARED_WIDTHPROVIDER_H
+
+#include "sst/basic-blocks/dsp/MidSide.h"
+
+namespace sst::effects_shared
+{
+template <typename T, size_t blockSize, bool useGetFloatValue = false> struct WidthProvider
+{
+    T *asT() { return static_cast<T *>(this); }
+
+    template <typename lipol>
+    inline void applyWidth(float *__restrict L, float *__restrict R, lipol &widthS, lipol &widthM)
+    {
+        namespace sdsp = sst::basic_blocks::dsp;
+        float M alignas(16)[blockSize], S alignas(16)[blockSize];
+        sdsp::encodeMS<blockSize>(L, R, M, S);
+        widthS.multiply_block(S, blockSize >> 2);
+        if constexpr (T::useLinearWidth())
+            widthM.multiply_block(M, blockSize >> 2);
+
+        sdsp::decodeMS<blockSize>(M, S, L, R);
+    }
+
+    basic_blocks::params::ParamMetaData getWidthParam() const
+    {
+        auto res = basic_blocks::params::ParamMetaData().withName("Width");
+        if constexpr (!T::useLinearWidth())
+            return res.asDecibelNarrow().withDefault(0.f);
+        else
+            return res.asPercentBipolar().withRange(-2.f, 2.f).withDefault(1.f);
+    }
+
+    int getDefaultWidth() const
+    {
+        if constexpr (!T::useLinearWidth())
+            return 0.f;
+        else
+            return 1.f;
+    }
+
+    inline float internalValue(int idx)
+    {
+        if constexpr (useGetFloatValue)
+            return asT()->getFloatParam(idx);
+        else
+            return asT()->floatValue(idx);
+    }
+    template <typename lipol>
+    void setWidthTarget(lipol &widthS, lipol &widthM, int idx, float scale = 1.f)
+    {
+        if constexpr (!T::useLinearWidth())
+            widthS.set_target_smoothed(asT()->dbToLinear(internalValue(idx)) * scale);
+        else
+        {
+            auto iv = internalValue(idx);
+            widthS.set_target_smoothed(iv);
+
+            // basically up the mid by up to 2x
+            auto mv = 1.0f / (std::max(0.5f, std::fabs(iv)));
+            widthM.set_target_smoothed(mv);
+        }
+    }
+};
+} // namespace sst::effects_shared
+#endif // WIDTHPROVIDER_H

--- a/include/sst/effects/Delay.h
+++ b/include/sst/effects/Delay.h
@@ -181,7 +181,7 @@ template <typename FXConfig> struct Delay : core::EffectTemplateBase<FXConfig>
     // Still don't have it here.
     static constexpr int max_delay_length{1 << 18};
     typename core::EffectTemplateBase<FXConfig>::lipol_ps_blocksz feedback, crossfeed, aligpan, pan,
-        mix, width;
+        mix, widthS, widthM;
     float buffer alignas(
         16)[2][max_delay_length + sst::basic_blocks::tables::SurgeSincTableProvider::FIRipol_N];
 
@@ -290,7 +290,7 @@ template <typename FXConfig> inline void Delay<FXConfig>::setvars(bool init)
     }
 
     mix.set_target_smoothed(this->floatValue(dly_mix));
-    this->setWidthTarget(width, dly_width);
+    this->setWidthTarget(widthS, widthM, dly_width);
     pan.set_target_smoothed(std::clamp(this->floatValue(dly_input_channel), -1.f, 1.f));
 
     lp.coeff_LP2B(lp.calc_omega(this->floatValue(dly_highcut) / 12.0), 0.707);
@@ -303,7 +303,8 @@ template <typename FXConfig> inline void Delay<FXConfig>::setvars(bool init)
         feedback.instantize();
         crossfeed.instantize();
         mix.instantize();
-        width.instantize();
+        widthS.instantize();
+        widthM.instantize();
         pan.instantize();
         lp.coeff_instantize();
         hp.coeff_instantize();
@@ -433,7 +434,7 @@ template <typename FXConfig> inline void Delay<FXConfig>::processBlock(float *da
     }
 
     // scale width
-    this->applyWidth(tbufferL, tbufferR, width);
+    this->applyWidth(tbufferL, tbufferR, widthS, widthM);
 
     mix.fade_2_blocks_inplace(dataL, tbufferL, dataR, tbufferR, this->blockSize_quad);
 

--- a/include/sst/effects/Flanger.h
+++ b/include/sst/effects/Flanger.h
@@ -194,7 +194,7 @@ template <typename FXConfig> struct Flanger : core::EffectTemplateBase<FXConfig>
     float lfosandhtarget[2][COMBS_PER_CHANNEL];
     float vweights[2][COMBS_PER_CHANNEL];
 
-    sdsp::lipol_sse<FXConfig::blockSize, false> width;
+    sdsp::lipol_sse<FXConfig::blockSize, false> widthS, widthM;
     bool haveProcessed{false};
 
     const static int LFO_TABLE_SIZE = 8192;
@@ -599,8 +599,8 @@ inline void Flanger<FXConfig>::processBlock(float *__restrict dataL, float *__re
         voices.process();
     }
 
-    this->setWidthTarget(width, fl_width, 1.0 / 3.0);
-    this->applyWidth(dataL, dataR, width);
+    this->setWidthTarget(widthS, widthM, fl_width, 1.0 / 3.0);
+    this->applyWidth(dataL, dataR, widthS, widthM);
 }
 
 } // namespace sst::effects::flanger

--- a/include/sst/effects/Phaser.h
+++ b/include/sst/effects/Phaser.h
@@ -71,7 +71,8 @@ template <typename FXConfig> struct Phaser : core::EffectTemplateBase<FXConfig>
         n_bq_units_initialised = n_bq_units;
         feedback.setBlockSize(FXConfig::blockSize * this->slowrate);
         tone.setBlockSize(FXConfig::blockSize);
-        width.set_blocksize(FXConfig::blockSize);
+        widthS.set_blocksize(FXConfig::blockSize);
+        widthM.set_blocksize(FXConfig::blockSize);
         lp.setBlockSize(FXConfig::blockSize);
         hp.setBlockSize(FXConfig::blockSize);
         mix.set_blocksize(FXConfig::blockSize);
@@ -101,7 +102,8 @@ template <typename FXConfig> struct Phaser : core::EffectTemplateBase<FXConfig>
         mix.set_target(1.f);
 
         tone.instantize();
-        width.instantize();
+        widthS.instantize();
+        widthM.instantize();
         mix.instantize();
 
         modLFOL.setSampleRate(this->sampleRate());
@@ -230,7 +232,7 @@ template <typename FXConfig> struct Phaser : core::EffectTemplateBase<FXConfig>
         feedback.newValue(0.95f * this->floatValue(ph_feedback));
         tone.newValue(std::clamp(this->floatValue(ph_tone), -1.f, 1.f));
 
-        this->setWidthTarget(width, ph_width);
+        this->setWidthTarget(widthS, widthM, ph_width);
 
         // lowpass range is from MIDI note 136 down to 57 (~21.1 kHz down to 220 Hz)
         // highpass range is from MIDI note 34 to 136(~61 Hz to ~21.1 kHz)
@@ -289,7 +291,7 @@ template <typename FXConfig> struct Phaser : core::EffectTemplateBase<FXConfig>
             hp.process_block(L, R);
         }
 
-        this->applyWidth(L, R, width);
+        this->applyWidth(L, R, widthS, widthM);
 
         mix.set_target_smoothed(std::clamp(this->floatValue(ph_mix), 0.f, 1.f));
         mix.fade_2_blocks_inplace(dataL, L, dataR, R, this->blockSize_quad);
@@ -359,8 +361,7 @@ fxdata->p[ph_mod_rate].deactivated = false;
         return pmd().withName("Unknown " + std::to_string(idx));
     }
 
-    sst::basic_blocks::dsp::lipol_sse<FXConfig::blockSize, false> width alignas(16), mix
-        alignas(16);
+    sst::basic_blocks::dsp::lipol_sse<FXConfig::blockSize, false> widthS, widthM, mix;
 
     float L alignas(16)[FXConfig::blockSize], R alignas(16)[FXConfig::blockSize];
 

--- a/include/sst/effects/Reverb1.h
+++ b/include/sst/effects/Reverb1.h
@@ -128,7 +128,7 @@ template <typename FXConfig> struct Reverb1 : core::EffectTemplateBase<FXConfig>
     float out_tap alignas(16)[rev_taps];
     float predelay alignas(16)[max_rev_dly];
     int delay_time alignas(16)[rev_taps];
-    typename core::EffectTemplateBase<FXConfig>::lipol_ps_blocksz mix, width;
+    typename core::EffectTemplateBase<FXConfig>::lipol_ps_blocksz mix, widthS, widthM;
 
     void update_rtime();
     void update_rsize() { loadpreset(shape); }
@@ -192,8 +192,9 @@ template <typename FXConfig> inline void Reverb1<FXConfig>::initialize()
     mix.set_target(1.f); // Should be the smoothest
     mix.instantize();
 
-    width.set_target(1.f); // Should be the smoothest
-    width.instantize();
+    widthS.set_target(1.f); // Should be the smoothest
+    widthM.set_target(1.f);
+    widthS.instantize();
 
     for (int t = 0; t < rev_taps; t++)
     {
@@ -233,7 +234,7 @@ inline void Reverb1<FXConfig>::processBlock(float *__restrict dataL, float *__re
     b = (b + 1) & 31;
 
     mix.set_target_smoothed(this->floatValue(rev1_mix));
-    this->setWidthTarget(width, rev1_width);
+    this->setWidthTarget(widthS, widthM, rev1_width);
 
     int pdtime = (int)(float)this->sampleRate() *
                  this->noteToPitchIgnoringTuning(12 * this->floatValue(rev1_predelay)) *
@@ -324,7 +325,7 @@ inline void Reverb1<FXConfig>::processBlock(float *__restrict dataL, float *__re
     }
 
     // scale width
-    this->applyWidth(wetL, wetR, width);
+    this->applyWidth(wetL, wetR, widthS, widthM);
 
     mix.fade_2_blocks_inplace(dataL, wetL, dataR, wetR, this->blockSize_quad);
 }

--- a/include/sst/effects/Reverb2.h
+++ b/include/sst/effects/Reverb2.h
@@ -226,7 +226,7 @@ template <typename FXConfig> struct Reverb2 : core::EffectTemplateBase<FXConfig>
     quadr_osc _lfo;
     float last_decay_time = -1.0;
 
-    sdsp::lipol_sse<FXConfig::blockSize, false> width, mix;
+    sdsp::lipol_sse<FXConfig::blockSize, false> widthS, widthM, mix;
 
     inline int msToSamples(float ms, float scale, float samplerate)
     {
@@ -415,7 +415,7 @@ template <typename FXConfig> void Reverb2<FXConfig>::processBlock(float *dataL, 
     _lf_damp_coefficent.newValue(0.2 * this->floatValue(rev2_lf_damping));
     _modulation.newValue(this->floatValue(rev2_modulation) * this->sampleRate() * 0.001f * 5.f);
 
-    this->setWidthTarget(width, rev2_width);
+    this->setWidthTarget(widthS, widthM, rev2_width);
 
     mix.set_target_smoothed(this->floatValue(rev2_mix));
 
@@ -481,7 +481,7 @@ template <typename FXConfig> void Reverb2<FXConfig>::processBlock(float *dataL, 
     }
 
     // scale width
-    this->applyWidth(wetL, wetR, width);
+    this->applyWidth(wetL, wetR, widthS, widthM);
 
     mix.fade_2_blocks_inplace(dataL, wetL, dataR, wetR);
 }

--- a/include/sst/voice-effects/VoiceEffectCore.h
+++ b/include/sst/voice-effects/VoiceEffectCore.h
@@ -181,6 +181,11 @@ template <typename VFXConfig> struct VoiceEffectTemplateBase : public VFXConfig:
         }
     }
 
+    static constexpr bool useLinearWidth()
+    {
+        return true; // all voice effects use new style width
+    }
+
 #define HASMEM(M, GetSig, DVAL, PARENS)                                                            \
     template <typename T, typename = void> struct has_##M : std::false_type                        \
     {                                                                                              \


### PR DESCRIPTION
This modifies the linear width so that as the sides drop or gain the mid attempts to gain or drop accordingly to keep roughly equal level. Addresses https://github.com/surge-synthesizer/shortcircuit-xt/issues/1012#issuecomment-3145466089

First add a base class which provides width calculations and has two smoothers, then use that in the bus effects

Add a voice effect variant and port Tiltnoise

Make it so the mids increase as the sides decrease and so on