### PR TITLE
replace ordinal indicator º with a proper degree sign °

### DIFF
--- a/include/sst/voice-effects/utilities/StereoTool.h
+++ b/include/sst/voice-effects/utilities/StereoTool.h
@@ -65,7 +65,7 @@ struct StereoTool : core::VoiceEffectTemplateBase<VFXConfig>,
                 .withRange(-halfPi, halfPi)
                 .withDefault(0.f)
                 .withName("Rotation")
-                .withLinearScaleFormatting("º", 90 / halfPi);
+                .withLinearScaleFormatting("°", 90 / halfPi);
         case fpWidth:
             return this->getWidthParam().withName("Width");
         case fpOutputBalance:


### PR DESCRIPTION
Unfortunately, as simple as that. There are no other degree-like characters in the whole repo.

Obviously shouldn't break the build ...I hope.