### PR TITLE
Fix three ConcreteConfig bugs affecting non-Chorus effects

### DIFF
--- a/include/sst/effects/ConcreteConfig.h
+++ b/include/sst/effects/ConcreteConfig.h
@@ -72,8 +72,8 @@ struct ConcreteConfig
 
     static inline float envelopeRateLinear(GlobalStorage *s, float f)
     {
-        // Must use positive base: pow(-2, non-integer) = NaN; pow(-2, odd) = negative.
-        return pow(2.f, -f) * blockSize / (s->sampleRate);
+        // envelope rate linear is 2^f normalized for sample frequency over the block
+        return pow(2.f, -f) * (blockSize / (s->sampleRate));
     }
 
     static inline float temposyncRatio(GlobalStorage *s, EffectStorage *e, int idx) { return 1; }

--- a/include/sst/effects/ConcreteConfig.h
+++ b/include/sst/effects/ConcreteConfig.h
@@ -73,7 +73,7 @@ struct ConcreteConfig
     static inline float envelopeRateLinear(GlobalStorage *s, float f)
     {
         // Must use positive base: pow(-2, non-integer) = NaN; pow(-2, odd) = negative.
-        return 1.f * blockSize / (s->sampleRate) * powf(2.f, f);
+        return pow(2.f, -f) * blockSize / (s->sampleRate);
     }
 
     static inline float temposyncRatio(GlobalStorage *s, EffectStorage *e, int idx) { return 1; }

--- a/include/sst/effects/ConcreteConfig.h
+++ b/include/sst/effects/ConcreteConfig.h
@@ -72,7 +72,8 @@ struct ConcreteConfig
 
     static inline float envelopeRateLinear(GlobalStorage *s, float f)
     {
-        return 1.f * blockSize / (s->sampleRate) * pow(-2, f);
+        // Must use positive base: pow(-2, non-integer) = NaN; pow(-2, odd) = negative.
+        return 1.f * blockSize / (s->sampleRate) * powf(2.f, f);
     }
 
     static inline float temposyncRatio(GlobalStorage *s, EffectStorage *e, int idx) { return 1; }
@@ -97,7 +98,7 @@ struct ConcreteConfig
         return 1.0 / noteToPitch(s, p);
     }
 
-    static inline float dbToLinear(GlobalStorage *s, float f) { return 1; }
+    static inline float dbToLinear(GlobalStorage *s, float f) { return powf(10.f, f / 20.f); }
 };
 } // namespace sst::effects::core
 


### PR DESCRIPTION
## Summary

Two bugs in `ConcreteConfig` cause audible failures when bus effects are used
standalone (without full Surge state). Both were latent until `ConcreteConfig`
was exercised in a real-time audio context outside of Surge.

### Fix 1: `envelopeRateLinear` — `pow(-2, f)` → `powf(2.f, f)`

`pow(-2, f)` with a non-integer floating-point exponent triggers a domain error
under IEEE 754 / C99: a negative real base raised to a non-integer exponent
requires complex arithmetic, so `pow()` returns NaN. The NaN propagates into
the LFO phase accumulator and silences the output entirely.

**Observed symptom:** Flanger produces complete silence.

The correct base is `+2`. Surge's production `table_envrate_linear` is initialized
as `blockSize / (sampleRate * pow(2, f))`; `ConcreteConfig` approximates the
same function with a direct call. The minus sign was a typo.

### Fix 2: `dbToLinear` — `return 1` → `powf(10.f, f / 20.f)`

The original was a stub that evaluated every dB value to unity gain. The correct
formula is the standard dBFS → linear amplitude conversion. Surge's production
implementation uses a lookup table that computes the same function.

**Observed symptom:** Reverb1 Width parameter had no audible effect regardless
of knob position.

## Notes

A third change (`isDeactivated: false → true`) was originally included but has
been removed per maintainer feedback. The correct approach for per-parameter
deactivation state is a domain-specific config implementation rather than a
blanket return value.

## Full analysis

A detailed writeup including call sites and Python verification of the NaN
behavior is at:
https://github.com/bwanab/surge-single-effect-lv2/blob/main/docs/concreteconfig-bugs.md

## Test context

These fixes were validated in a JUCE-based LV2 plugin host (MODEP on Raspberry Pi
aarch64) using `ConcreteConfig` directly. Flanger and Reverb1 both behaved
correctly after the fixes.