### PR TITLE
Step the Bonsai tape noise LCG in unsigned arithmetic

### DIFF
--- a/include/sst/effects/Bonsai.h
+++ b/include/sst/effects/Bonsai.h
@@ -722,9 +722,7 @@ template <size_t blockSize> inline void blockabs(float *src)
     }
 }
 
-// The multiply overflows int32_t for all but a handful of inputs, and signed overflow
-// is undefined. An LCG wants modular arithmetic anyway, so do the step unsigned, where
-// the wrap is defined, and convert the result back.
+// step unsigned so the LCG wrap is defined rather than signed overflow
 inline int32_t super_simple_noise(int32_t last)
 {
     return (int32_t)((uint32_t)last * 1103515245u + 12345u);

--- a/include/sst/effects/Bonsai.h
+++ b/include/sst/effects/Bonsai.h
@@ -722,7 +722,13 @@ template <size_t blockSize> inline void blockabs(float *src)
     }
 }
 
-inline int32_t super_simple_noise(int32_t last) { return last * 1103515245 + 12345; }
+// The multiply overflows int32_t for all but a handful of inputs, and signed overflow
+// is undefined. An LCG wants modular arithmetic anyway, so do the step unsigned, where
+// the wrap is defined, and convert the result back.
+inline int32_t super_simple_noise(int32_t last)
+{
+    return (int32_t)((uint32_t)last * 1103515245u + 12345u);
+}
 template <size_t blockSize> inline void noise(float &last, float *__restrict dst)
 {
     int32_t temp alignas(16)[blockSize] = {};


### PR DESCRIPTION
### What

`super_simple_noise` is a linear congruential generator:

```cpp
inline int32_t super_simple_noise(int32_t last) { return last * 1103515245 + 12345; }
```

Both operands are `int32_t`, so the multiply overflows for all but a handful of inputs, and signed overflow is undefined behaviour. UBSan reports it from Surge XT's `[fx]` suite:

```
Bonsai.h:725:63: runtime error: signed integer overflow:
1103527590 * 1103515245 cannot be represented in type 'int'
    #2 sst::effects::bonsai::Bonsai<surge::sstfx::SurgeFXConfig>::tape_noise(...) Bonsai.h:1449
    #3 sst::effects::bonsai::Bonsai<surge::sstfx::SurgeFXConfig>::processBlock(float*, float*) Bonsai.h:1576
    #4 surge::sstfx::SurgeSSTFXBase<...>::process(float*, float*) SurgeSSTFXAdapter.h:186
    #5 Effect::process_ringout(float*, float*, bool) Effect.cpp:166
```

An LCG is *defined* in terms of modular arithmetic, so stepping it as `uint32_t` — where the wrap is specified rather than undefined — is what the algorithm actually wants. The result converts straight back.

### The sequence is preserved

Comparing both forms over a million steps per seed, at `-O0` through `-O3`, the output is identical for seeds `0`, `1`, `-1`, `INT32_MAX` and `123456789`.

They differ in exactly one case: when the state is exactly `INT32_MIN`. There the current code is undefined and the optimiser folds the multiply away entirely, returning `last + 12345` rather than stepping the generator — so the "change" is only relative to behaviour that is already arbitrary.

Surge XT's `[fx]` suite is unchanged at **3202892 assertions across 9 test cases**, and reverting just this hunk and rebuilding brings the report straight back, so the check is tied to the change.

### One thing I noticed but did not touch

`noise()` takes `float &last` and round-trips the generator state through it:

```cpp
temp[0] = super_simple_noise(last);   // float -> int32_t
...
last = temp[blockSize - 1];           // int32_t -> float
```

`float` has 24 bits of mantissa, so any state above 2^24 loses its low bits on the way out and comes back rounded — the low bits of an LCG are the part being sampled here, and the generator does not run as a true LCG across block boundaries.

It also looks like the route to the `INT32_MIN` case above: a state near `INT32_MAX` rounds up to `2147483648.0f` on the way into the float, and converting that back to `int32_t` is itself out of range.

Both of those change the noise this effect produces, so I have left them alone — happy to follow up if you want either addressed.

Assisted-By: Claude Code (Claude Opus 5) — X: manuaudiomix
