### PR TITLE
Bump the fmt pin to 12.1.0 to unbreak the macOS CI legs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if (${SST_EFFECTS_BUILD_TESTS})
     if (NOT TARGET fmt)
         CPMAddPackage(NAME fmt
                 GITHUB_REPOSITORY fmtlib/fmt
-                GIT_TAG 10.2.1
+                GIT_TAG 12.1.0
         )
     endif ()
 


### PR DESCRIPTION
Follow-up to your note on #253. fmt 10.2.1 no longer compiles under current Apple clang, so all three `Test mac-*` legs and `Build Examples (macos-latest)` fail inside fmt before any sst-effects source is reached.

12.1.0 is the pin `sst-basic-blocks` already uses in an identical `CPMAddPackage` block, so this aligns the two rather than picking a new version.

Verified locally on macOS: at 10.2.1 the `fmt` target fails with 9 errors; at 12.1.0 it builds clean and `sst-effects-test` passes 288073 assertions in 4 test cases.

One correction to what I said on #253 — I claimed a bump had blast radius across consumers. It does not: fmt is only linked into `sst-effects-test` and `CLIExample`, both inside the top-level-only block, and the `CPMAddPackage` is guarded by `if (NOT TARGET fmt)`.

Assisted-By: Claude Code (Claude Opus 5)